### PR TITLE
Rediseñar checkout para la estética pública

### DIFF
--- a/assets/sdb/20240903_checkout.sql
+++ b/assets/sdb/20240903_checkout.sql
@@ -1,0 +1,42 @@
+-- Estructura para el nuevo flujo de checkout (inscripciones y pagos)
+
+CREATE TABLE IF NOT EXISTS `checkout_inscripciones` (
+  `id_inscripcion` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `id_curso` INT UNSIGNED NOT NULL,
+  `nombre` VARCHAR(120) NOT NULL,
+  `apellido` VARCHAR(120) NOT NULL,
+  `email` VARCHAR(150) NOT NULL,
+  `telefono` VARCHAR(60) NOT NULL,
+  `dni` VARCHAR(40) DEFAULT NULL,
+  `direccion` VARCHAR(200) DEFAULT NULL,
+  `ciudad` VARCHAR(120) DEFAULT NULL,
+  `provincia` VARCHAR(120) DEFAULT NULL,
+  `pais` VARCHAR(120) NOT NULL DEFAULT 'Argentina',
+  `acepta_tyc` TINYINT(1) NOT NULL DEFAULT 0,
+  `precio_total` DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+  `moneda` VARCHAR(10) NOT NULL DEFAULT 'ARS',
+  `creado_en` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `actualizado_en` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_inscripcion`),
+  KEY `idx_checkout_inscripciones_curso` (`id_curso`),
+  CONSTRAINT `fk_checkout_inscripciones_curso` FOREIGN KEY (`id_curso`) REFERENCES `cursos` (`id_curso`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `checkout_pagos` (
+  `id_pago` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `id_inscripcion` INT UNSIGNED NOT NULL,
+  `metodo` VARCHAR(40) NOT NULL,
+  `estado` VARCHAR(30) NOT NULL DEFAULT 'pendiente',
+  `monto` DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+  `moneda` VARCHAR(10) NOT NULL DEFAULT 'ARS',
+  `comprobante_path` VARCHAR(255) DEFAULT NULL,
+  `comprobante_nombre` VARCHAR(255) DEFAULT NULL,
+  `comprobante_mime` VARCHAR(120) DEFAULT NULL,
+  `comprobante_tamano` INT UNSIGNED DEFAULT NULL,
+  `observaciones` VARCHAR(255) DEFAULT NULL,
+  `creado_en` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `actualizado_en` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_pago`),
+  KEY `idx_checkout_pagos_inscripcion` (`id_inscripcion`),
+  CONSTRAINT `fk_checkout_pagos_inscripcion` FOREIGN KEY (`id_inscripcion`) REFERENCES `checkout_inscripciones` (`id_inscripcion`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/assets/styles/style_capacitacion.css
+++ b/assets/styles/style_capacitacion.css
@@ -157,6 +157,11 @@ body {
     padding: 14px 24px;
     border-radius: 50px;
     font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    text-decoration: none;
     width: 100%;
     margin-top: 22px;
     transition: .3s;

--- a/assets/styles/style_certificacion.css
+++ b/assets/styles/style_certificacion.css
@@ -172,6 +172,11 @@
       padding: 14px 24px;
       border-radius: 50px;
       font-weight: 700;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      text-decoration: none;
       width: 100%;
       margin-top: 22px;
       transition: .3s;

--- a/capacitacion.php
+++ b/capacitacion.php
@@ -176,7 +176,7 @@ $modalidad_nombres_str = implode(' - ', $modalidad_nombres);
                             </div>
                         </div>
 
-                        <button class="enroll-button" onclick="inscribirse()"><i class="fas fa-user-plus me-2"></i>Inscribirse Ahora</button>
+                        <a class="enroll-button" href="checkout/checkout.php?id_curso=<?php echo isset($curso['id_curso']) ? (int)$curso['id_curso'] : 0; ?>"><i class="fas fa-user-plus me-2"></i>Inscribirse Ahora</a>
                     </div>
                 </div>
             </div>
@@ -188,9 +188,6 @@ $modalidad_nombres_str = implode(' - ', $modalidad_nombres);
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        function inscribirse() {
-            alert('Funcionalidad de inscripción - Conectar con tu sistema.');
-        }
         document.addEventListener('DOMContentLoaded', () => {
             document.querySelectorAll('.content-wrapper, .details-card').forEach((el, i) => {
                 el.style.opacity = '0';

--- a/certificacion.php
+++ b/certificacion.php
@@ -167,9 +167,9 @@ $modalidad_nombres_str = implode(' - ', $modalidad_nombres);
                             </div>
                         </div>
 
-                        <button class="enroll-button" onclick="solicitarCertificacion()">
+                        <a class="enroll-button" href="checkout/checkout.php?id_curso=<?php echo isset($cert['id_curso']) ? (int)$cert['id_curso'] : 0; ?>">
                             <i class="fa-solid fa-paper-plane me-2"></i> Solicitar certificación
-                        </button>
+                        </a>
                     </div>
                 </div>
             </div>
@@ -181,9 +181,6 @@ $modalidad_nombres_str = implode(' - ', $modalidad_nombres);
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        function solicitarCertificacion() {
-            alert('Flujo de solicitud de certificación - Conectar con tu backend.');
-        }
         document.addEventListener('DOMContentLoaded', () => {
             document.querySelectorAll('.content-wrapper, .details-card').forEach((el, i) => {
                 el.style.opacity = '0';

--- a/checkout/checkout.php
+++ b/checkout/checkout.php
@@ -1,343 +1,493 @@
 <?php
-// finalizar_compra.php
-include '../sbd.php';
-include '../admin/header.php';
-include '../admin/aside.php';
-include '../admin/footer.php';
+session_start();
+require_once '../sbd.php';
 
 $page_title = "Checkout | Instituto de Formación";
-$page_description = "checkout - página de capacitación del Instituto de Formación de Operadores";
-
+$page_description = "Completá tu inscripción en tres pasos.";
 
 $id_curso = isset($_GET['id_curso']) ? (int)$_GET['id_curso'] : 0;
 
-// Curso
 $st = $con->prepare("SELECT * FROM cursos WHERE id_curso = :id");
-$st->execute([':id'=>$id_curso]);
+$st->execute([':id' => $id_curso]);
 $curso = $st->fetch(PDO::FETCH_ASSOC);
-if(!$curso){
-  echo "<div class='content-wrapper'><section class='content'><div class='container-fluid'><div class='alert alert-danger'>Curso no encontrado.</div></div></section></div>";
-  exit;
+
+$precio_vigente = null;
+if ($curso) {
+    $pv = $con->prepare("
+        SELECT precio, moneda, vigente_desde
+        FROM curso_precio_hist
+        WHERE id_curso = :c
+          AND vigente_desde <= NOW()
+          AND (vigente_hasta IS NULL OR vigente_hasta > NOW())
+        ORDER BY vigente_desde DESC
+        LIMIT 1
+    ");
+    $pv->execute([':c' => $id_curso]);
+    $precio_vigente = $pv->fetch(PDO::FETCH_ASSOC);
 }
 
-// Precio vigente (ARS)
-$pv = $con->prepare("
-  SELECT precio, moneda, vigente_desde
-  FROM curso_precio_hist
-  WHERE id_curso = :c
-    AND vigente_desde <= NOW()
-    AND (vigente_hasta IS NULL OR vigente_hasta > NOW())
-  ORDER BY vigente_desde DESC
-  LIMIT 1
-");
-$pv->execute([':c'=>$id_curso]);
-$precio_vigente = $pv->fetch(PDO::FETCH_ASSOC);
+function h($s)
+{
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+}
 
-function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+$flash_success = $_SESSION['checkout_success'] ?? null;
+$flash_error   = $_SESSION['checkout_error'] ?? null;
+unset($_SESSION['checkout_success'], $_SESSION['checkout_error']);
 ?>
 <!DOCTYPE html>
 <html lang="es">
+<?php
+$asset_base_path = '../';
+$base_path = '../';
+$page_styles = '<link rel="stylesheet" href="../checkout/css/style.css">';
+include '../head.php';
+?>
+<body class="checkout-body">
+    <?php include '../nav.php'; ?>
 
-
-<?php $page_styles = '<link rel="stylesheet" href="css/style.css">'; ?>
-<?php include("head.php"); ?>
-
-<body class="hold-transition sidebar-mini">
-  <div class="wrapper">
-    <div class="content-wrapper">
-
-      <section class="content-header">
-        <div class="container-fluid">
-          <div class="row mb-2">
-            <div class="col-sm-6"><h1><i class="fas fa-shopping-cart"></i> Finalizar compra</h1></div>
-            <div class="col-sm-6">
-              <ol class="breadcrumb float-sm-right">
-                <li class="breadcrumb-item"><a href="../admin/dashboard.php"><i class="fas fa-home"></i> Inicio</a></li>
-                <li class="breadcrumb-item"><a href="cursos.php"><i class="fas fa-list"></i> Cursos</a></li>
-                <li class="breadcrumb-item active"><i class="fas fa-cash-register"></i> Checkout</li>
-              </ol>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="content">
-        <div class="container-fluid">
-
-          <div class="card card-outline card-primary">
-            <div class="card-header card-header-gradient">
-              <h3 class="card-title mb-0"><i class="fas fa-book"></i> <?php echo h($curso['nombre_curso']); ?></h3>
+    <main class="checkout-main">
+        <div class="container">
+            <div class="mb-4">
+                <a class="back-link" href="<?php echo $base_path; ?>index.php#cursos">
+                    <i class="fas fa-arrow-left"></i>
+                    Volver al listado de cursos
+                </a>
             </div>
 
-            <!-- UN SOLO FORM -->
-            <form id="checkoutForm" action="procesarsbd.php" method="POST" enctype="multipart/form-data" novalidate>
-              <input type="hidden" name="__accion" id="__accion" value="">
-              <input type="hidden" name="crear_orden" value="1">
-              <input type="hidden" name="id_curso" value="<?php echo (int)$id_curso; ?>">
+            <div class="row justify-content-center">
+                <div class="col-xl-10">
+                    <div class="checkout-card">
+                        <div class="checkout-header">
+                            <h1>Finalizá tu inscripción</h1>
+                            <p>Seguí los pasos para reservar tu lugar en la capacitación elegida.</p>
+                            <?php if ($curso): ?>
+                                <div class="checkout-course-name">
+                                    <i class="fas fa-graduation-cap"></i>
+                                    <?php echo h($curso['nombre_curso']); ?>
+                                </div>
+                            <?php endif; ?>
+                        </div>
 
-              <div class="card-body p-0">
-                <ul class="nav nav-tabs px-3 pt-3" role="tablist">
-                  <li class="nav-item">
-                    <a class="nav-link active" data-toggle="tab" href="#paso1" role="tab">
-                      <i class="fas fa-receipt"></i> 1) Resumen
-                    </a>
-                  </li>
-                  <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#paso2" role="tab">
-                      <i class="fas fa-id-card"></i> 2) Inscripción
-                    </a>
-                  </li>
-                  <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#paso3" role="tab">
-                      <i class="fas fa-credit-card"></i> 3) Pago
-                    </a>
-                  </li>
-                </ul>
-
-                <div class="tab-content p-3">
-                  <!-- PASO 1 -->
-                  <div class="tab-pane fade show active" id="paso1" role="tabpanel">
-                    <div class="row">
-                      <div class="col-md-7">
-                        <h5>Resumen del curso</h5>
-                        <p class="mb-2"><strong>Nombre:</strong> <?php echo h($curso['nombre_curso']); ?></p>
-                        <p class="mb-2"><strong>Duración:</strong> <?php echo h($curso['duracion']); ?></p>
-                        <p class="mb-2"><strong>Complejidad:</strong> <?php echo h($curso['complejidad']); ?></p>
-                        <p><strong>Descripción:</strong><br><?php echo nl2br(h($curso['descripcion_curso'])); ?></p>
-                      </div>
-                      <div class="col-md-5">
-                        <div class="alert alert-info">
-                          <h5 class="mb-1"><i class="fas fa-tag"></i> Precio</h5>
-                          <?php if ($precio_vigente): ?>
-                            <div class="display-4" style="font-size:2rem;">
-                              ARS <?php echo number_format((float)$precio_vigente['precio'], 2, ',', '.'); ?>
+                        <?php if (!$curso): ?>
+                            <div class="checkout-content">
+                                <div class="alert alert-danger checkout-alert mb-0" role="alert">
+                                    No pudimos encontrar la capacitación seleccionada. Volvé al listado e intentá nuevamente.
+                                </div>
                             </div>
-                            <small>Vigente desde: <?php echo date('d/m/Y H:i', strtotime($precio_vigente['vigente_desde'])); ?></small>
-                          <?php else: ?>
-                            <div class="text-muted">No hay precio vigente configurado.</div>
-                          <?php endif; ?>
-                          <input type="hidden" name="precio_checkout" value="<?php echo $precio_vigente ? (float)$precio_vigente['precio'] : 0; ?>">
-                        </div>
-                      </div>
-                    </div>
-                    <div class="d-flex justify-content-end">
-                      <button type="button" class="btn btn-primary" id="btnToPaso2">Continuar <i class="fas fa-arrow-right ml-1"></i></button>
-                    </div>
-                  </div>
+                        <?php else: ?>
+                            <div class="checkout-stepper">
+                                <div class="checkout-step is-active" data-step="1">
+                                    <div class="step-index">1</div>
+                                    <div class="step-label">
+                                        Resumen
+                                        <span class="step-helper">Detalles del curso</span>
+                                    </div>
+                                </div>
+                                <div class="checkout-step" data-step="2">
+                                    <div class="step-index">2</div>
+                                    <div class="step-label">
+                                        Datos personales
+                                        <span class="step-helper">Completá tu información</span>
+                                    </div>
+                                </div>
+                                <div class="checkout-step" data-step="3">
+                                    <div class="step-index">3</div>
+                                    <div class="step-label">
+                                        Pago
+                                        <span class="step-helper">Elegí el método</span>
+                                    </div>
+                                </div>
+                            </div>
 
-                  <!-- PASO 2 -->
-                  <div class="tab-pane fade" id="paso2" role="tabpanel">
-                    <h5 class="mb-3">Datos del inscripto</h5>
-                    <div class="form-row">
-                      <div class="form-group col-md-6">
-                        <label for="nombre" class="required-field">Nombre</label>
-                        <input type="text" class="form-control" id="nombre" name="nombre_insc" placeholder="Nombre">
-                      </div>
-                      <div class="form-group col-md-6">
-                        <label for="apellido" class="required-field">Apellido</label>
-                        <input type="text" class="form-control" id="apellido" name="apellido_insc" placeholder="Apellido">
-                      </div>
-                    </div>
-                    <div class="form-row">
-                      <div class="form-group col-md-6">
-                        <label for="email" class="required-field">Email</label>
-                        <input type="email" class="form-control" id="email" name="email_insc" placeholder="correo@dominio.com">
-                      </div>
-                      <div class="form-group col-md-6">
-                        <label for="telefono" class="required-field">Teléfono</label>
-                        <input type="text" class="form-control" id="telefono" name="tel_insc" placeholder="+54 11 5555-5555">
-                      </div>
-                    </div>
-                    <div class="form-row">
-                      <div class="form-group col-md-4">
-                        <label for="dni">DNI</label>
-                        <input type="text" class="form-control" id="dni" name="dni_insc" placeholder="Documento">
-                      </div>
-                      <div class="form-group col-md-8">
-                        <label for="direccion">Dirección</label>
-                        <input type="text" class="form-control" id="direccion" name="dir_insc" placeholder="Calle y número">
-                      </div>
-                    </div>
-                    <div class="form-row">
-                      <div class="form-group col-md-4">
-                        <label for="ciudad">Ciudad</label>
-                        <input type="text" class="form-control" id="ciudad" name="ciu_insc">
-                      </div>
-                      <div class="form-group col-md-4">
-                        <label for="provincia">Provincia</label>
-                        <input type="text" class="form-control" id="provincia" name="prov_insc">
-                      </div>
-                      <div class="form-group col-md-4">
-                        <label for="pais">País</label>
-                        <input type="text" class="form-control" id="pais" name="pais_insc" value="Argentina">
-                      </div>
-                    </div>
+                            <div class="checkout-content">
+                                <?php if ($flash_success): ?>
+                                    <div class="alert alert-success checkout-alert" role="alert">
+                                        <div class="d-flex align-items-start gap-2">
+                                            <i class="fas fa-circle-check mt-1"></i>
+                                            <div>
+                                                <strong>¡Inscripción enviada!</strong>
+                                                <?php if (!empty($flash_success['orden'])): ?>
+                                                    <div>Número de orden: #<?php echo str_pad((string)(int)$flash_success['orden'], 6, '0', STR_PAD_LEFT); ?>.</div>
+                                                <?php endif; ?>
+                                                <div class="small mt-1">Te contactaremos por correo para completar el proceso.</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <?php endif; ?>
+                                <?php if ($flash_error): ?>
+                                    <div class="alert alert-danger checkout-alert" role="alert">
+                                        <div class="d-flex align-items-start gap-2">
+                                            <i class="fas fa-triangle-exclamation mt-1"></i>
+                                            <div>
+                                                <strong>No pudimos procesar tu inscripción.</strong>
+                                                <div class="small mt-1"><?php echo h($flash_error); ?></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <?php endif; ?>
 
-                    <div class="form-group form-check">
-                      <input type="checkbox" class="form-check-input" id="acepta" name="acepta_tyc" value="1">
-                      <label class="form-check-label required-field" for="acepta">
-                        Acepto los Términos y Condiciones del sitio
-                      </label>
-                    </div>
+                                <form id="checkoutForm" action="../admin/procesarsbd.php" method="POST" enctype="multipart/form-data" novalidate>
+                                    <input type="hidden" name="__accion" id="__accion" value="">
+                                    <input type="hidden" name="crear_orden" value="1">
+                                    <input type="hidden" name="id_curso" value="<?php echo (int)$id_curso; ?>">
+                                    <input type="hidden" name="precio_checkout" value="<?php echo $precio_vigente ? (float)$precio_vigente['precio'] : 0; ?>">
 
-                    <div class="d-flex justify-content-between">
-                      <button type="button" class="btn btn-secondary" id="btnBackPaso1"><i class="fas fa-arrow-left mr-1"></i> Volver</button>
-                      <button type="button" class="btn btn-primary" id="btnToPaso3">Continuar <i class="fas fa-arrow-right ml-1"></i></button>
-                    </div>
-                  </div>
+                                    <div class="step-panel active" data-step="1">
+                                        <div class="row g-4 align-items-stretch">
+                                            <div class="col-lg-7">
+                                                <div class="summary-card h-100">
+                                                    <h5>Resumen del curso</h5>
+                                                    <div class="summary-item">
+                                                        <strong>Nombre</strong>
+                                                        <span><?php echo h($curso['nombre_curso']); ?></span>
+                                                    </div>
+                                                    <div class="summary-item">
+                                                        <strong>Duración</strong>
+                                                        <span><?php echo h($curso['duracion'] ?? 'A definir'); ?></span>
+                                                    </div>
+                                                    <div class="summary-item">
+                                                        <strong>Nivel</strong>
+                                                        <span><?php echo h($curso['complejidad'] ?? 'Intermedio'); ?></span>
+                                                    </div>
+                                                    <div class="summary-description mt-3">
+                                                        <?php echo nl2br(h($curso['descripcion_curso'] ?? '')); ?>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="col-lg-5">
+                                                <div class="summary-card h-100 d-flex flex-column justify-content-between">
+                                                    <h5>Inversión</h5>
+                                                    <div class="price-highlight">
+                                                        <?php if ($precio_vigente): ?>
+                                                            <div class="price-value">
+                                                                <?php echo strtoupper($precio_vigente['moneda'] ?? 'ARS'); ?> <?php echo number_format((float)$precio_vigente['precio'], 2, ',', '.'); ?>
+                                                            </div>
+                                                            <span class="price-note">Vigente desde <?php echo date('d/m/Y H:i', strtotime($precio_vigente['vigente_desde'])); ?></span>
+                                                        <?php else: ?>
+                                                            <div class="text-muted">Precio a confirmar por el equipo comercial.</div>
+                                                        <?php endif; ?>
+                                                    </div>
+                                                    <div class="small text-muted mt-3">
+                                                        El equipo se pondrá en contacto para coordinar disponibilidad, medios de pago y comenzar tu proceso.
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="nav-actions">
+                                            <span></span>
+                                            <button type="button" class="btn btn-gradient btn-rounded" data-next="2">
+                                                Continuar al paso 2
+                                                <i class="fas fa-arrow-right ms-2"></i>
+                                            </button>
+                                        </div>
+                                    </div>
 
-                  <!-- PASO 3 -->
-                  <div class="tab-pane fade" id="paso3" role="tabpanel">
-                    <h5 class="mb-3">Pago</h5>
+                                    <div class="step-panel" data-step="2">
+                                        <div class="row g-3">
+                                            <div class="col-md-6">
+                                                <label for="nombre" class="form-label required-field">Nombre</label>
+                                                <input type="text" class="form-control" id="nombre" name="nombre_insc" placeholder="Nombre" autocomplete="given-name">
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="apellido" class="form-label required-field">Apellido</label>
+                                                <input type="text" class="form-control" id="apellido" name="apellido_insc" placeholder="Apellido" autocomplete="family-name">
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="email" class="form-label required-field">Email</label>
+                                                <input type="email" class="form-control" id="email" name="email_insc" placeholder="correo@dominio.com" autocomplete="email">
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label for="telefono" class="form-label required-field">Teléfono</label>
+                                                <input type="text" class="form-control" id="telefono" name="tel_insc" placeholder="+54 11 5555-5555" autocomplete="tel">
+                                            </div>
+                                            <div class="col-md-4">
+                                                <label for="dni" class="form-label">DNI</label>
+                                                <input type="text" class="form-control" id="dni" name="dni_insc" placeholder="Documento">
+                                            </div>
+                                            <div class="col-md-8">
+                                                <label for="direccion" class="form-label">Dirección</label>
+                                                <input type="text" class="form-control" id="direccion" name="dir_insc" placeholder="Calle y número" autocomplete="address-line1">
+                                            </div>
+                                            <div class="col-md-4">
+                                                <label for="ciudad" class="form-label">Ciudad</label>
+                                                <input type="text" class="form-control" id="ciudad" name="ciu_insc" autocomplete="address-level2">
+                                            </div>
+                                            <div class="col-md-4">
+                                                <label for="provincia" class="form-label">Provincia</label>
+                                                <input type="text" class="form-control" id="provincia" name="prov_insc" autocomplete="address-level1">
+                                            </div>
+                                            <div class="col-md-4">
+                                                <label for="pais" class="form-label">País</label>
+                                                <input type="text" class="form-control" id="pais" name="pais_insc" value="Argentina" autocomplete="country-name">
+                                            </div>
+                                        </div>
+                                        <div class="terms-check mt-4">
+                                            <input type="checkbox" class="form-check-input mt-1" id="acepta" name="acepta_tyc" value="1">
+                                            <label class="form-check-label" for="acepta">
+                                                Confirmo que los datos ingresados son correctos y acepto los <a href="#" target="_blank" rel="noopener">Términos y Condiciones</a>.
+                                            </label>
+                                        </div>
+                                        <div class="nav-actions">
+                                            <button type="button" class="btn btn-outline-light btn-rounded" data-prev="1">
+                                                <i class="fas fa-arrow-left me-2"></i>
+                                                Volver
+                                            </button>
+                                            <button type="button" class="btn btn-gradient btn-rounded" data-next="3">
+                                                Continuar al paso 3
+                                                <i class="fas fa-arrow-right ms-2"></i>
+                                            </button>
+                                        </div>
+                                    </div>
 
-                    <div class="form-group">
-                      <div class="custom-control custom-radio">
-                        <input type="radio" id="mp" name="metodo_pago" class="custom-control-input" value="mp">
-                        <label class="custom-control-label" for="mp">
-                          Mercado Pago (próximamente) — mostrará botón de MP
-                        </label>
-                      </div>
-                      <div class="custom-control custom-radio">
-                        <input type="radio" id="transf" name="metodo_pago" class="custom-control-input" value="transferencia" checked>
-                        <label class="custom-control-label" for="transf">
-                          Transferencia bancaria (subí el comprobante)
-                        </label>
-                      </div>
-                    </div>
+                                    <div class="step-panel" data-step="3">
+                                        <div class="payment-box">
+                                            <h5>Método de pago</h5>
+                                            <label class="payment-option">
+                                                <input type="radio" id="metodo_transfer" name="metodo_pago" value="transferencia" checked>
+                                                <div class="payment-info">
+                                                    <strong>Transferencia bancaria</strong>
+                                                    <span>Subí el comprobante de tu transferencia.</span>
+                                                </div>
+                                            </label>
+                                            <label class="payment-option mt-3">
+                                                <input type="radio" id="metodo_mp" name="metodo_pago" value="mercado_pago">
+                                                <div class="payment-info">
+                                                    <strong>Mercado Pago</strong>
+                                                    <span>Próximamente disponible. Te avisaremos cuando esté habilitado.</span>
+                                                </div>
+                                            </label>
 
-                    <div id="box-transferencia" class="border rounded p-3 mb-3">
-                      <p class="mb-2"><strong>Datos bancarios</strong></p>
-                      <ul class="mb-3">
-                        <li>Banco: Tu Banco</li>
-                        <li>CBU: 0000000000000000000000</li>
-                        <li>Alias: tuempresa.cursos</li>
-                      </ul>
-                      <div class="form-row">
-                        <div class="form-group col-md-8">
-                          <label for="comprobante" class="required-field">Archivo de comprobante (JPG/PNG/PDF, máx 5MB)</label>
-                          <input type="file" class="form-control-file" id="comprobante" name="comprobante">
-                        </div>
-                        <div class="form-group col-md-4">
-                          <label for="obs_pago">Observaciones</label>
-                          <input type="text" class="form-control" id="obs_pago" name="obs_pago" placeholder="Opcional">
-                        </div>
-                      </div>
-                    </div>
+                                            <div class="payment-details" id="transferDetails">
+                                                <div class="bank-data">
+                                                    <strong>Datos bancarios</strong>
+                                                    <ul class="mb-0 mt-2 ps-3">
+                                                        <li>Banco: Tu Banco</li>
+                                                        <li>CBU: 0000000000000000000000</li>
+                                                        <li>Alias: tuempresa.cursos</li>
+                                                    </ul>
+                                                </div>
+                                                <div class="row g-3">
+                                                    <div class="col-lg-8">
+                                                        <label for="comprobante" class="form-label required-field">Comprobante de pago</label>
+                                                        <input type="file" class="form-control" id="comprobante" name="comprobante" accept=".jpg,.jpeg,.png,.pdf">
+                                                        <div class="upload-label">Formatos aceptados: JPG, PNG o PDF. Tamaño máximo 5 MB.</div>
+                                                    </div>
+                                                    <div class="col-lg-4">
+                                                        <label for="obs_pago" class="form-label">Observaciones</label>
+                                                        <input type="text" class="form-control" id="obs_pago" name="obs_pago" placeholder="Opcional">
+                                                    </div>
+                                                </div>
+                                            </div>
 
-                    <div id="box-mp" class="border rounded p-3 mb-3" style="display:none;">
-                      <p class="mb-2"><strong>Mercado Pago</strong></p>
-                      <p class="text-muted">Aquí irá el botón/checkout de MP (aún no implementado).</p>
-                    </div>
+                                            <div class="payment-details hidden" id="mpDetails">
+                                                <div class="summary-card">
+                                                    <p class="mb-0 text-muted">Pronto podrás completar el pago con Mercado Pago directamente desde esta pantalla.</p>
+                                                </div>
+                                            </div>
+                                        </div>
 
-                    <div class="d-flex justify-content-between">
-                      <button type="button" class="btn btn-secondary" id="btnBackPaso2"><i class="fas fa-arrow-left mr-1"></i> Volver</button>
-                      <button type="button" class="btn btn-success" id="btnConfirmar">
-                        <i class="fas fa-check"></i> Confirmar y enviar
-                      </button>
+                                        <div class="nav-actions">
+                                            <button type="button" class="btn btn-outline-light btn-rounded" data-prev="2">
+                                                <i class="fas fa-arrow-left me-2"></i>
+                                                Volver
+                                            </button>
+                                            <button type="button" class="btn btn-gradient btn-rounded" id="btnConfirmar">
+                                                Confirmar inscripción
+                                                <i class="fas fa-paper-plane ms-2"></i>
+                                            </button>
+                                        </div>
+                                        <div class="checkout-footer text-center mt-4">
+                                            Al confirmar, enviaremos los datos a nuestro equipo para validar tu lugar y nos comunicaremos por correo electrónico.
+                                        </div>
+                                    </div>
+                                </form>
+                            </div>
+                        <?php endif; ?>
                     </div>
-                  </div>
                 </div>
-              </div>
-            </form>
-          </div>
-
+            </div>
         </div>
-      </section>
-    </div>
-  </div>
+    </main>
 
-<script>
-  // Helpers SweetAlert con look Bootstrap
-  function swalConfirm({title, text, icon='question', confirmText='Sí', cancelText='Cancelar'}){
-    return Swal.fire({
-      title, text, icon, showCancelButton:true, confirmButtonText:confirmText, cancelButtonText:cancelText,
-      reverseButtons:true, buttonsStyling:false,
-      customClass:{ confirmButton:'btn btn-primary mx-1', cancelButton:'btn btn-outline-secondary mx-1' }
-    });
-  }
-  function showTab(sel){ $('a[href="'+sel+'"]').tab('show'); }
+    <?php include '../footer.php'; ?>
 
-  function validarPaso2(){
-    const req = [
-      {id:'nombre', label:'Nombre'},
-      {id:'apellido', label:'Apellido'},
-      {id:'email', label:'Email'},
-      {id:'telefono', label:'Teléfono'}
-    ];
-    for(const r of req){
-      const el = document.getElementById(r.id);
-      if(!el || !el.value || el.value.trim()===''){
-        showTab('#paso2');
-        el && el.focus();
-        Swal.fire({icon:'error', title:'Faltan datos', html:'<div style="text-align:left;">• '+r.label+'</div>'});
-        return false;
-      }
-    }
-    const email = document.getElementById('email').value.trim();
-    const okMail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-    if(!okMail){
-      showTab('#paso2');
-      document.getElementById('email').focus();
-      Swal.fire({icon:'error', title:'Email inválido', text:'Ingresá un correo válido.'});
-      return false;
-    }
-    if(!document.getElementById('acepta').checked){
-      showTab('#paso2');
-      Swal.fire({icon:'warning', title:'Términos y Condiciones', text:'Debés aceptar los T&C para continuar.'});
-      return false;
-    }
-    return true;
-  }
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script>
+        (function () {
+            const card = document.querySelector('.checkout-card');
+            const steps = Array.from(document.querySelectorAll('.checkout-step'));
+            const panels = Array.from(document.querySelectorAll('.step-panel'));
+            if (!steps.length || !panels.length) {
+                return;
+            }
 
-  function validarPaso3(){
-    const mp = document.getElementById('mp').checked;
-    const tf = document.getElementById('transf').checked;
-    if(!mp && !tf){
-      showTab('#paso3');
-      Swal.fire({icon:'error', title:'Seleccioná un método de pago'});
-      return false;
-    }
-    if(tf){
-      const f = document.getElementById('comprobante').files[0];
-      if(!f){
-        showTab('#paso3');
-        Swal.fire({icon:'error', title:'Falta comprobante', text:'Adjuntá el archivo de la transferencia.'});
-        return false;
-      }
-      const okType = ['image/jpeg','image/png','application/pdf'].includes(f.type);
-      if(!okType){ Swal.fire({icon:'error', title:'Tipo no permitido', text:'JPG, PNG o PDF.'}); return false; }
-      const max5 = 5 * 1024 * 1024;
-      if(f.size > max5){ Swal.fire({icon:'error', title:'Archivo muy grande', text:'Máximo 5 MB.'}); return false; }
-    }
-    return true;
-  }
+            let currentStep = 1;
 
-  // Navegación
-  document.getElementById('btnToPaso2').addEventListener('click',()=>showTab('#paso2'));
-  document.getElementById('btnBackPaso1').addEventListener('click',()=>showTab('#paso1'));
-  document.getElementById('btnToPaso3').addEventListener('click',()=>{
-    if(validarPaso2()) showTab('#paso3');
-  });
-  document.getElementById('btnBackPaso2').addEventListener('click',()=>showTab('#paso2'));
+            const goToStep = (target) => {
+                currentStep = target;
+                steps.forEach(step => {
+                    const stepIndex = parseInt(step.dataset.step, 10);
+                    step.classList.toggle('is-active', stepIndex === target);
+                    step.classList.toggle('is-complete', stepIndex < target);
+                });
+                panels.forEach(panel => {
+                    const panelIndex = parseInt(panel.dataset.step, 10);
+                    panel.classList.toggle('active', panelIndex === target);
+                });
+                if (card) {
+                    window.scrollTo({ top: card.offsetTop - 80, behavior: 'smooth' });
+                }
+            };
 
-  // Toggle boxes de pago
-  document.getElementById('mp').addEventListener('change', function(){
-    document.getElementById('box-mp').style.display = this.checked ? 'block' : 'none';
-    document.getElementById('box-transferencia').style.display = this.checked ? 'none' : 'block';
-  });
-  document.getElementById('transf').addEventListener('change', function(){
-    document.getElementById('box-transferencia').style.display = this.checked ? 'block' : 'none';
-    document.getElementById('box-mp').style.display = this.checked ? 'none' : 'block';
-  });
+            const showAlert = (icon, title, message) => {
+                Swal.fire({
+                    icon,
+                    title,
+                    html: message,
+                    confirmButtonText: 'Entendido',
+                    customClass: {
+                        confirmButton: 'btn btn-gradient btn-rounded'
+                    },
+                    buttonsStyling: false
+                });
+            };
 
-  // Confirmar
-  document.getElementById('btnConfirmar').addEventListener('click', async function(){
-    if(!validarPaso2() || !validarPaso3()) return;
-    const res = await swalConfirm({title:'Confirmar compra', text:'¿Deseás enviar la inscripción y el pago?', confirmText:'Sí, confirmar'});
-    if(!res.isConfirmed) return;
-    document.getElementById('__accion').value = 'crear_orden';
-    document.getElementById('checkoutForm').submit();
-  });
-</script>
+            const validateStep = (step) => {
+                if (step === 2) {
+                    const required = [
+                        { id: 'nombre', label: 'Nombre' },
+                        { id: 'apellido', label: 'Apellido' },
+                        { id: 'email', label: 'Email' },
+                        { id: 'telefono', label: 'Teléfono' }
+                    ];
+                    const missing = required.find(field => {
+                        const el = document.getElementById(field.id);
+                        return !el || !el.value || el.value.trim() === '';
+                    });
+                    if (missing) {
+                        goToStep(2);
+                        showAlert('error', 'Faltan datos', `Completá el campo <strong>${missing.label}</strong> para continuar.`);
+                        return false;
+                    }
+                    const email = document.getElementById('email').value.trim();
+                    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                    if (!emailPattern.test(email)) {
+                        goToStep(2);
+                        showAlert('error', 'Email inválido', 'Ingresá un correo electrónico válido.');
+                        return false;
+                    }
+                    const terms = document.getElementById('acepta');
+                    if (!terms.checked) {
+                        goToStep(2);
+                        showAlert('warning', 'Términos y Condiciones', 'Debés aceptar los Términos y Condiciones para continuar.');
+                        return false;
+                    }
+                }
+                if (step === 3) {
+                    const mp = document.getElementById('metodo_mp').checked;
+                    const transfer = document.getElementById('metodo_transfer').checked;
+                    if (!mp && !transfer) {
+                        goToStep(3);
+                        showAlert('error', 'Seleccioná un método de pago', 'Elegí una forma de pago para continuar.');
+                        return false;
+                    }
+                    if (transfer) {
+                        const fileInput = document.getElementById('comprobante');
+                        const file = fileInput.files[0];
+                        if (!file) {
+                            goToStep(3);
+                            showAlert('error', 'Falta el comprobante', 'Adjuntá el comprobante de la transferencia.');
+                            return false;
+                        }
+                        const allowedTypes = ['image/jpeg', 'image/png', 'application/pdf'];
+                        if (!allowedTypes.includes(file.type)) {
+                            goToStep(3);
+                            showAlert('error', 'Archivo no permitido', 'Solo se aceptan archivos JPG, PNG o PDF.');
+                            return false;
+                        }
+                        const maxSize = 5 * 1024 * 1024;
+                        if (file.size > maxSize) {
+                            goToStep(3);
+                            showAlert('error', 'Archivo demasiado grande', 'El archivo debe pesar hasta 5 MB.');
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            };
+
+            document.querySelectorAll('[data-next]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const next = parseInt(btn.dataset.next, 10);
+                    if (Number.isNaN(next)) {
+                        return;
+                    }
+                    if (currentStep === 2 && !validateStep(2)) {
+                        return;
+                    }
+                    goToStep(next);
+                });
+            });
+
+            document.querySelectorAll('[data-prev]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const prev = parseInt(btn.dataset.prev, 10);
+                    if (Number.isNaN(prev)) {
+                        return;
+                    }
+                    goToStep(prev);
+                });
+            });
+
+            const mpRadio = document.getElementById('metodo_mp');
+            const transferRadio = document.getElementById('metodo_transfer');
+            const transferDetails = document.getElementById('transferDetails');
+            const mpDetails = document.getElementById('mpDetails');
+
+            const togglePaymentDetails = () => {
+                if (transferRadio.checked) {
+                    transferDetails.classList.remove('hidden');
+                    mpDetails.classList.add('hidden');
+                } else if (mpRadio.checked) {
+                    mpDetails.classList.remove('hidden');
+                    transferDetails.classList.add('hidden');
+                }
+            };
+
+            mpRadio.addEventListener('change', togglePaymentDetails);
+            transferRadio.addEventListener('change', togglePaymentDetails);
+            togglePaymentDetails();
+
+            const form = document.getElementById('checkoutForm');
+            const confirmButton = document.getElementById('btnConfirmar');
+
+            confirmButton.addEventListener('click', () => {
+                if (!validateStep(2) || !validateStep(3)) {
+                    return;
+                }
+                Swal.fire({
+                    icon: 'question',
+                    title: 'Confirmar inscripción',
+                    text: '¿Deseás enviar la inscripción con los datos cargados?',
+                    showCancelButton: true,
+                    confirmButtonText: 'Sí, enviar',
+                    cancelButtonText: 'Cancelar',
+                    customClass: {
+                        confirmButton: 'btn btn-gradient btn-rounded me-2',
+                        cancelButton: 'btn btn-outline-light btn-rounded'
+                    },
+                    buttonsStyling: false,
+                    reverseButtons: true
+                }).then(result => {
+                    if (result.isConfirmed) {
+                        document.getElementById('__accion').value = 'crear_orden';
+                        form.submit();
+                    }
+                });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/checkout/css/style.css
+++ b/checkout/css/style.css
@@ -1,21 +1,418 @@
-.card-header-gradient {
-    background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
-    color: #fff;
+.checkout-body {
+    background: linear-gradient(180deg, #f3f7ff 0%, #ffffff 100%);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
-.nav-tabs .nav-link.active {
-    background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
-    color: #fff;
-    border-radius: 8px 8px 0 0;
+.checkout-main {
+    flex: 1 0 auto;
+    padding: 60px 0 80px;
+    background: radial-gradient(circle at 20% 20%, rgba(84, 153, 255, 0.12) 0%, transparent 60%),
+                radial-gradient(circle at 80% 0%, rgba(0, 200, 170, 0.12) 0%, transparent 55%);
 }
 
-.tab-content {
+.checkout-card {
     background: #fff;
-    border-radius: 0 8px 8px 8px;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, .06);
+    border-radius: 26px;
+    box-shadow: 0 32px 80px rgba(15, 41, 77, 0.14);
+    overflow: hidden;
+}
+
+.checkout-header {
+    background: linear-gradient(135deg, #1565d8 0%, #1b9aaa 100%);
+    color: #fff;
+    padding: 36px;
+}
+
+.checkout-header h1 {
+    font-size: 1.9rem;
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.checkout-header p {
+    margin: 0;
+    opacity: 0.85;
+}
+
+.checkout-course-name {
+    font-weight: 600;
+    font-size: 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.15);
+    margin-top: 18px;
+}
+
+.checkout-course-name i {
+    font-size: 1.1rem;
+}
+
+.checkout-stepper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 26px 36px 10px;
+    background: #f7f9fc;
+}
+
+.checkout-step {
+    flex: 1 1 200px;
+    background: #fff;
+    border-radius: 18px;
+    padding: 16px 18px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    border: 1px solid rgba(21, 101, 216, 0.18);
+    color: #617d98;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.checkout-step::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(21, 101, 216, 0.12) 0%, rgba(27, 154, 170, 0.12) 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.checkout-step.is-active,
+.checkout-step.is-complete {
+    color: #fff;
+    border-color: transparent;
+}
+
+.checkout-step.is-active::after,
+.checkout-step.is-complete::after {
+    opacity: 1;
+}
+
+.checkout-step.is-active {
+    background: linear-gradient(135deg, #1565d8 0%, #1b9aaa 100%);
+}
+
+.checkout-step.is-complete {
+    background: linear-gradient(135deg, #1b9aaa 0%, #20c997 100%);
+}
+
+.checkout-step .step-index {
+    z-index: 1;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.25);
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+.checkout-step .step-label {
+    z-index: 1;
+}
+
+.checkout-step .step-helper {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 500;
+    opacity: 0.75;
+}
+
+.checkout-content {
+    padding: 32px 36px 40px;
+}
+
+.step-panel {
+    display: none;
+    animation: fadeIn 0.35s ease;
+}
+
+.step-panel.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.summary-card,
+.details-card,
+.payment-box {
+    background: #f9fbff;
+    border-radius: 18px;
+    padding: 24px;
+    border: 1px solid rgba(21, 101, 216, 0.12);
+}
+
+.summary-card h5,
+.payment-box h5 {
+    font-weight: 700;
+    margin-bottom: 18px;
+    color: #1b2a4e;
+}
+
+.summary-item {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 12px;
+    font-size: 0.95rem;
+}
+
+.summary-item:last-child {
+    margin-bottom: 0;
+}
+
+.summary-item strong {
+    color: #284a75;
+    min-width: 120px;
+}
+
+.summary-description {
+    background: #fff;
+    border-radius: 14px;
+    padding: 16px;
+    border: 1px solid rgba(21, 101, 216, 0.08);
+    color: #4a607c;
+}
+
+.price-highlight {
+    background: linear-gradient(135deg, rgba(21, 101, 216, 0.1) 0%, rgba(27, 154, 170, 0.15) 100%);
+    border-radius: 18px;
+    padding: 22px;
+    text-align: center;
+    color: #12345b;
+}
+
+.price-value {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.price-note {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(18, 52, 91, 0.1);
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.checkout-alert {
+    margin-bottom: 24px;
+}
+
+.nav-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 32px;
+}
+
+.btn-rounded {
+    border-radius: 999px;
+    padding: 12px 28px;
+    font-weight: 600;
+}
+
+.btn-gradient {
+    background: linear-gradient(135deg, #1565d8 0%, #1b9aaa 100%);
+    border: none;
+    color: #fff;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-gradient:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 32px rgba(21, 101, 216, 0.25);
+    color: #fff;
+}
+
+.btn-outline-light {
+    color: #1b2a4e;
+    border-color: rgba(21, 101, 216, 0.35);
+}
+
+.btn-outline-light:hover {
+    background: rgba(21, 101, 216, 0.08);
+    color: #12345b;
 }
 
 .required-field::after {
     content: " *";
-    color: #dc3545;
+    color: #e74c3c;
+    font-weight: 700;
+}
+
+.form-label {
+    font-weight: 600;
+    color: #1b2a4e;
+}
+
+.form-control,
+.form-select {
+    border-radius: 14px;
+    padding: 12px 14px;
+    border: 1px solid rgba(21, 101, 216, 0.15);
+}
+
+.form-control:focus,
+.form-select:focus {
+    border-color: #1b9aaa;
+    box-shadow: 0 0 0 0.2rem rgba(21, 101, 216, 0.15);
+}
+
+.terms-check {
+    background: #f7f9fc;
+    border-radius: 14px;
+    padding: 16px 18px;
+    border: 1px solid rgba(21, 101, 216, 0.12);
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    font-size: 0.95rem;
+}
+
+.terms-check a {
+    color: #1565d8;
+    text-decoration: underline;
+}
+
+.payment-option {
+    border: 1px solid rgba(21, 101, 216, 0.15);
+    border-radius: 18px;
+    padding: 18px 20px;
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.payment-option:hover {
+    border-color: rgba(21, 101, 216, 0.35);
+    box-shadow: 0 10px 24px rgba(21, 101, 216, 0.08);
+}
+
+.payment-option input {
+    width: 20px;
+    height: 20px;
+}
+
+.payment-option .payment-info {
+    flex: 1 1 auto;
+}
+
+.payment-option strong {
+    display: block;
+    font-size: 1rem;
+    color: #1b2a4e;
+}
+
+.payment-option span {
+    font-size: 0.9rem;
+    color: #617d98;
+}
+
+.payment-details {
+    margin-top: 22px;
+}
+
+.bank-data {
+    background: rgba(21, 101, 216, 0.06);
+    border-radius: 14px;
+    padding: 18px;
+    margin-bottom: 18px;
+    color: #27496d;
+}
+
+.upload-label {
+    font-size: 0.9rem;
+    color: #617d98;
+    margin-top: 6px;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    background: rgba(21, 101, 216, 0.08);
+    color: #1565d8;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background 0.2s ease;
+}
+
+.back-link:hover {
+    background: rgba(21, 101, 216, 0.15);
+    color: #1565d8;
+}
+
+.checkout-footer {
+    margin-top: 24px;
+    font-size: 0.85rem;
+    color: #6c7a8b;
+}
+
+@media (max-width: 991.98px) {
+    .checkout-header {
+        padding: 28px;
+    }
+
+    .checkout-content {
+        padding: 28px 24px;
+    }
+
+    .checkout-stepper {
+        padding: 20px 24px 6px;
+    }
+
+    .checkout-step {
+        flex: 1 1 100%;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .checkout-main {
+        padding: 40px 0 60px;
+    }
+
+    .checkout-card {
+        border-radius: 18px;
+    }
+
+    .checkout-header h1 {
+        font-size: 1.6rem;
+    }
+
+    .nav-actions {
+        flex-direction: column;
+    }
+
+    .btn-rounded {
+        width: 100%;
+        text-align: center;
+    }
+
+    .terms-check {
+        flex-direction: column;
+    }
 }

--- a/footer.php
+++ b/footer.php
@@ -1,8 +1,9 @@
+<?php $base_path = $base_path ?? ''; ?>
 <footer class="bg-black text-white py-5">
     <div class="container">
         <div class="row">
             <div class="col-md-4 mb-4 mb-md-0">
-                <img src="logos/LOGO PNG-07.png" alt="Logo Instituto de Formación de Operadores" class="footer-logo mb-3">
+                <img src="<?php echo $base_path; ?>logos/LOGO PNG-07.png" alt="Logo Instituto de Formación de Operadores" class="footer-logo mb-3">
                 <p>&copy; 2023 Instituto de Formación de Operadores. Todos los derechos reservados.</p>
             </div>
             <div class="col-md-4 mb-4 mb-md-0">

--- a/head.php
+++ b/head.php
@@ -1,3 +1,4 @@
+<?php $asset_base_path = $asset_base_path ?? ''; ?>
 <head>
 
     <meta charset="UTF-8">
@@ -8,12 +9,12 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="stylesheet" href="assets\styles\style.css">
+    <link rel="stylesheet" href="<?php echo $asset_base_path; ?>assets/styles/style.css">
     <?= isset($page_styles) ? $page_styles : '' ?>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
 
-    <link rel="shortcut icon" href="assets\iconos\icono.png" type="image/png">
+    <link rel="shortcut icon" href="<?php echo $asset_base_path; ?>assets/iconos/icono.png" type="image/png">
 
 
 </head>

--- a/nav.php
+++ b/nav.php
@@ -1,7 +1,8 @@
+<?php $base_path = $base_path ?? ''; ?>
 <nav class="navbar navbar-expand-lg navbar-light bg-white sticky-top">
     <div class="container">
-        <a class="navbar-brand" href="index.php">
-            <img src="logos/LOGO PNG-03.png" alt="Logo">
+        <a class="navbar-brand" href="<?php echo $base_path; ?>index.php">
+            <img src="<?php echo $base_path; ?>logos/LOGO PNG-03.png" alt="Logo">
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
             <span class="navbar-toggler-icon"></span>
@@ -9,21 +10,21 @@
         <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
             <ul class="navbar-nav">
                 <li class="nav-item">
-                    <a class="nav-link" href="index.php#quienes-somos">Nosotros</a>
+                    <a class="nav-link" href="<?php echo $base_path; ?>index.php#quienes-somos">Nosotros</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="index.php#servicios-capacitacion">Servicios</a>
+                    <a class="nav-link" href="<?php echo $base_path; ?>index.php#servicios-capacitacion">Servicios</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="index.php#cursos">Cursos</a>
+                    <a class="nav-link" href="<?php echo $base_path; ?>index.php#cursos">Cursos</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="index.php#contacto">Contáctanos</a>
+                    <a class="nav-link" href="<?php echo $base_path; ?>index.php#contacto">Contáctanos</a>
                 </li>
                 <?php
                 if (isset($_SESSION["usuario"])) { ?>
                     <li class="nav-item">
-                        <a class="text-decoration-none" href="admin/admin.php">
+                        <a class="text-decoration-none" href="<?php echo $base_path; ?>admin/admin.php">
                             <button class="button-nav">
                                 panel adm
                                 <div class="arrow-wrapper">
@@ -34,7 +35,7 @@
                     </li>
                 <?php } else { ?>
                     <li class="nav-item">
-                        <a class="text-decoration-none" href="login.php">
+                        <a class="text-decoration-none" href="<?php echo $base_path; ?>login.php">
                             <button class="button-nav">
                                 iniciar sesion
                                 <div class="arrow-wrapper">

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!comprobantes/

--- a/uploads/comprobantes/.gitignore
+++ b/uploads/comprobantes/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- redesign the checkout page with the public site layout, a three-step progress indicator, and updated client-side validations
- allow the shared head, navigation, and footer includes to honour relative asset paths from nested directories
- link course and certification call-to-actions to the checkout flow while styling the buttons for anchor usage

## Testing
- php -l head.php
- php -l nav.php
- php -l footer.php
- php -l capacitacion.php
- php -l certificacion.php
- php -l checkout/checkout.php

------
https://chatgpt.com/codex/tasks/task_e_68ca119f78248322898d286add3d6cce