### PR TITLE
Normaliza rutas para recursos compartidos

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,14 @@
-<?php $base_path = $base_path ?? ''; ?>
+<?php
+if (!isset($base_path)) {
+    $scriptDir = trim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
+    if ($scriptDir === '') {
+        $base_path = '';
+    } else {
+        $depth = substr_count($scriptDir, '/') + 1;
+        $base_path = str_repeat('../', $depth);
+    }
+}
+?>
 <footer class="bg-black text-white py-5">
     <div class="container">
         <div class="row">

--- a/head.php
+++ b/head.php
@@ -1,4 +1,14 @@
-<?php $asset_base_path = $asset_base_path ?? ''; ?>
+<?php
+if (!isset($asset_base_path)) {
+    $scriptDir = trim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
+    if ($scriptDir === '') {
+        $asset_base_path = '';
+    } else {
+        $depth = substr_count($scriptDir, '/') + 1;
+        $asset_base_path = str_repeat('../', $depth);
+    }
+}
+?>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/nav.php
+++ b/nav.php
@@ -4,7 +4,15 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-
+if (!isset($base_path)) {
+    $scriptDir = trim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])), '/');
+    if ($scriptDir === '') {
+        $base_path = '';
+    } else {
+        $depth = substr_count($scriptDir, '/') + 1;
+        $base_path = str_repeat('../', $depth);
+    }
+}
 ?>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-white sticky-top">
@@ -27,8 +35,7 @@ if (session_status() === PHP_SESSION_NONE) {
                     <a class="nav-link" href="<?php echo $base_path; ?>index.php#cursos">Cursos</a>
                 </li>
                 <li class="nav-item">
-
-                    <a class="nav-link" href="index.php#contacto">Contactanos</a>
+                    <a class="nav-link" href="<?php echo $base_path; ?>index.php#contacto">Contactanos</a>
                 </li>
                 <?php
                 $permiso = isset($_SESSION["permiso"]) ? (int)$_SESSION["permiso"] : null;


### PR DESCRIPTION
## Summary
- calcula dinámicamente la ruta base para los assets compartidos en head.php
- ajusta nav.php y footer.php para reutilizar la ruta base sin depender de variables previas
- corrige el enlace de contacto para que use siempre la ruta calculada

## Testing
- php -l head.php
- php -l nav.php
- php -l footer.php

------
https://chatgpt.com/codex/tasks/task_e_68d45b2e21e08322beaad900c454e39b