### PR TITLE
Enforce login and improve checkout flow

### DIFF
--- a/checkout/mercadopago_init.php
+++ b/checkout/mercadopago_init.php
@@ -16,6 +16,10 @@ $responseCode = 200;
 $response = ['success' => false, 'message' => ''];
 
 try {
+    if (!isset($_SESSION['id_usuario']) && !isset($_SESSION['usuario'])) {
+        $responseCode = 401;
+        throw new RuntimeException('Debés iniciar sesión para continuar.');
+    }
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
         throw new RuntimeException('Método no permitido.');
     }
@@ -247,7 +251,9 @@ try {
     $response['preference_id'] = $preferenceId;
     $response['orden'] = $inscripcionId;
 } catch (Throwable $exception) {
-    $responseCode = $exception instanceof InvalidArgumentException ? 400 : 500;
+    if ($responseCode === 200) {
+        $responseCode = $exception instanceof InvalidArgumentException ? 400 : 500;
+    }
     $response['message'] = $exception->getMessage();
     checkout_log_event('checkout_mp_preference_fail', ['error' => $exception->getMessage()], $exception);
 }


### PR DESCRIPTION
## Summary
- require an authenticated session before allowing access to the checkout or Mercado Pago initialization endpoints
- accept capacitacion/certificacion identifiers in the checkout form and forward the purchase context to the thank-you page
- redirect successful manual checkouts to the thank-you page with contextual messaging and dynamic return links

## Testing
- php -l checkout/checkout.php
- php -l checkout/mercadopago_init.php
- php -l admin/procesarsbd.php
- php -l checkout/gracias.php

------
https://chatgpt.com/codex/tasks/task_e_68d46e3382088322b2553c99f5f9d6dc