### PR TITLE
Add certification-specific checkout flow

### DIFF
--- a/admin/aside.php
+++ b/admin/aside.php
@@ -94,6 +94,13 @@
               </ul>
             </li>
 
+            <li class="nav-item">
+              <a href="certificaciones.php" class="nav-link">
+                <i class="fas fa-solid fa-file-signature"></i>
+                <p>Certificaciones</p>
+              </a>
+            </li>
+
           </ul>
         </nav>
         <!-- /.sidebar-menu -->

--- a/admin/certificaciones.php
+++ b/admin/certificaciones.php
@@ -1,0 +1,229 @@
+<?php
+require_once '../sbd.php';
+include '../admin/header.php';
+include '../admin/aside.php';
+include '../admin/footer.php';
+
+$certStmt = $con->prepare(
+    'SELECT cc.*, c.nombre_curso
+       FROM checkout_certificaciones cc
+ INNER JOIN cursos c ON c.id_curso = cc.id_curso
+   ORDER BY cc.creado_en DESC'
+);
+$certStmt->execute();
+$certificaciones = $certStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$estadoConfig = [
+    1 => ['label' => 'En revisión', 'class' => 'badge bg-warning'],
+    2 => ['label' => 'Aprobada', 'class' => 'badge bg-info'],
+    3 => ['label' => 'Pago registrado', 'class' => 'badge bg-success'],
+    4 => ['label' => 'Rechazada', 'class' => 'badge bg-danger'],
+];
+
+$adminSuccess = $_SESSION['certificacion_admin_success'] ?? null;
+$adminError = $_SESSION['certificacion_admin_error'] ?? null;
+unset($_SESSION['certificacion_admin_success'], $_SESSION['certificacion_admin_error']);
+
+function h(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
+
+function formatEstado(array $config, ?int $estado): string
+{
+    if ($estado === null || !isset($config[$estado])) {
+        return '<span class="badge bg-secondary">Sin estado</span>';
+    }
+    $data = $config[$estado];
+    return sprintf('<span class="%s">%s</span>', h($data['class']), h($data['label']));
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Certificaciones | Panel Administrativo</title>
+</head>
+
+<body class="hold-transition sidebar-mini layout-fixed">
+    <div class="wrapper">
+        <div class="content-wrapper">
+            <section class="content">
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="card">
+                                <div class="card-header d-flex justify-content-between align-items-center">
+                                    <h3 class="card-title">Solicitudes de certificación</h3>
+                                </div>
+                                <div class="card-body">
+                                    <?php if ($adminSuccess): ?>
+                                        <div class="alert alert-success alert-dismissible fade show" role="alert">
+                                            <i class="fas fa-circle-check me-2"></i><?php echo h($adminSuccess); ?>
+                                            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar"><span aria-hidden="true">&times;</span></button>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($adminError): ?>
+                                        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                                            <i class="fas fa-circle-xmark me-2"></i><?php echo h($adminError); ?>
+                                            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar"><span aria-hidden="true">&times;</span></button>
+                                        </div>
+                                    <?php endif; ?>
+
+                                    <div class="table-responsive">
+                                        <table id="tablaCertificaciones" class="table table-bordered table-striped align-middle">
+                                            <thead>
+                                                <tr>
+                                                    <th style="width: 70px">#</th>
+                                                    <th>Curso</th>
+                                                    <th>Solicitante</th>
+                                                    <th>Email</th>
+                                                    <th>Teléfono</th>
+                                                    <th>Estado</th>
+                                                    <th>Enviado</th>
+                                                    <th>PDF</th>
+                                                    <th>Observaciones</th>
+                                                    <th style="width: 160px">Acciones</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <?php foreach ($certificaciones as $cert): ?>
+                                                    <?php
+                                                    $certId = (int)$cert['id_certificacion'];
+                                                    $estado = isset($cert['id_estado']) ? (int)$cert['id_estado'] : null;
+                                                    $puedeAprobar = in_array($estado, [1, 4], true);
+                                                    $puedeRechazar = in_array($estado, [1, 2], true);
+                                                    $fecha = '';
+                                                    if (!empty($cert['creado_en'])) {
+                                                        $timestamp = strtotime((string)$cert['creado_en']);
+                                                        if ($timestamp) {
+                                                            $fecha = date('d/m/Y H:i', $timestamp);
+                                                        }
+                                                    }
+                                                    $observaciones = trim((string)($cert['observaciones'] ?? ''));
+                                                    $observacionesResumen = $observaciones;
+                                                    if ($observaciones !== '' && function_exists('mb_substr')) {
+                                                        $observacionesResumen = mb_strlen($observaciones, 'UTF-8') > 120
+                                                            ? mb_substr($observaciones, 0, 120, 'UTF-8') . '…'
+                                                            : $observaciones;
+                                                    } elseif (strlen($observacionesResumen) > 120) {
+                                                        $observacionesResumen = substr($observacionesResumen, 0, 120) . '…';
+                                                    }
+                                                    ?>
+                                                    <tr>
+                                                        <td><strong>#<?php echo h(str_pad((string)$certId, 5, '0', STR_PAD_LEFT)); ?></strong></td>
+                                                        <td><?php echo h($cert['nombre_curso'] ?? ''); ?></td>
+                                                        <td>
+                                                            <div class="fw-semibold"><?php echo h(trim(($cert['nombre'] ?? '') . ' ' . ($cert['apellido'] ?? ''))); ?></div>
+                                                        </td>
+                                                        <td><a href="mailto:<?php echo h($cert['email'] ?? ''); ?>"><?php echo h($cert['email'] ?? ''); ?></a></td>
+                                                        <td><?php echo h($cert['telefono'] ?? ''); ?></td>
+                                                        <td><?php echo formatEstado($estadoConfig, $estado); ?></td>
+                                                        <td><?php echo h($fecha); ?></td>
+                                                        <td>
+                                                            <?php if (!empty($cert['pdf_path'])): ?>
+                                                                <a class="btn btn-outline-primary btn-sm" href="../<?php echo h(ltrim((string)$cert['pdf_path'], '/')); ?>" target="_blank" rel="noopener">
+                                                                    <i class="fas fa-file-pdf me-1"></i>Ver PDF
+                                                                </a>
+                                                            <?php else: ?>
+                                                                <span class="text-muted">Sin archivo</span>
+                                                            <?php endif; ?>
+                                                        </td>
+                                                        <td>
+                                                            <?php if ($observacionesResumen !== ''): ?>
+                                                                <span title="<?php echo h($observaciones); ?>"><?php echo h($observacionesResumen); ?></span>
+                                                            <?php else: ?>
+                                                                <span class="text-muted">-</span>
+                                                            <?php endif; ?>
+                                                        </td>
+                                                        <td>
+                                                            <div class="d-flex flex-column gap-2">
+                                                                <?php if ($puedeAprobar): ?>
+                                                                    <button type="button" class="btn btn-success btn-sm btn-aprobar" data-id="<?php echo $certId; ?>">
+                                                                        <i class="fas fa-check me-1"></i>Aprobar
+                                                                    </button>
+                                                                <?php endif; ?>
+                                                                <?php if ($puedeRechazar): ?>
+                                                                    <button type="button" class="btn btn-danger btn-sm btn-rechazar" data-id="<?php echo $certId; ?>">
+                                                                        <i class="fas fa-times me-1"></i>Rechazar
+                                                                    </button>
+                                                                <?php endif; ?>
+                                                                <?php if (!$puedeAprobar && !$puedeRechazar): ?>
+                                                                    <span class="text-muted small">Sin acciones disponibles</span>
+                                                                <?php endif; ?>
+                                                            </div>
+                                                            <form id="formCert<?php echo $certId; ?>" action="procesarsbd.php" method="POST" class="d-none">
+                                                                <input type="hidden" name="__accion" value="">
+                                                                <input type="hidden" name="id_certificacion" value="<?php echo $certId; ?>">
+                                                                <input type="hidden" name="motivo" value="">
+                                                            </form>
+                                                        </td>
+                                                    </tr>
+                                                <?php endforeach; ?>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const table = $("#tablaCertificaciones").DataTable({
+                responsive: true,
+                lengthChange: true,
+                autoWidth: false,
+                order: [[0, 'desc']],
+                language: {
+                    url: "//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json"
+                },
+                buttons: ["copy", "csv", "excel", "pdf", "print", "colvis"]
+            });
+            table.buttons().container().appendTo('#tablaCertificaciones_wrapper .col-md-6:eq(0)');
+
+            document.querySelectorAll('.btn-aprobar').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const id = btn.dataset.id;
+                    const form = document.getElementById('formCert' + id);
+                    if (!form) {
+                        return;
+                    }
+                    if (!confirm('¿Confirmás la aprobación de esta certificación?')) {
+                        return;
+                    }
+                    form.querySelector('input[name="__accion"]').value = 'aprobar_certificacion';
+                    form.submit();
+                });
+            });
+
+            document.querySelectorAll('.btn-rechazar').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const id = btn.dataset.id;
+                    const form = document.getElementById('formCert' + id);
+                    if (!form) {
+                        return;
+                    }
+                    const reason = prompt('Indicá el motivo del rechazo (opcional):', '');
+                    if (reason === null) {
+                        return;
+                    }
+                    if (!confirm('¿Confirmás el rechazo de esta certificación?')) {
+                        return;
+                    }
+                    form.querySelector('input[name="__accion"]').value = 'rechazar_certificacion';
+                    form.querySelector('input[name="motivo"]').value = reason.trim();
+                    form.submit();
+                });
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/admin/procesarsbd.php
+++ b/admin/procesarsbd.php
@@ -76,6 +76,34 @@ function registrar_historico_certificacion(PDO $con, int $idCertificacion, int $
     ]);
 }
 
+function obtener_usuario_id_de_sesion(): int
+{
+    if (isset($_SESSION['id_usuario']) && is_numeric($_SESSION['id_usuario'])) {
+        $id = (int)$_SESSION['id_usuario'];
+        if ($id > 0) {
+            return $id;
+        }
+    }
+
+    if (!isset($_SESSION['usuario'])) {
+        return 0;
+    }
+
+    $sessionUsuario = $_SESSION['usuario'];
+
+    if (is_numeric($sessionUsuario)) {
+        $id = (int)$sessionUsuario;
+        return $id > 0 ? $id : 0;
+    }
+
+    if (is_array($sessionUsuario) && isset($sessionUsuario['id_usuario']) && is_numeric($sessionUsuario['id_usuario'])) {
+        $id = (int)$sessionUsuario['id_usuario'];
+        return $id > 0 ? $id : 0;
+    }
+
+    return 0;
+}
+
 /* =================== MAIN FLOW ================== */
 $checkoutUploadAbs = null;
 $checkoutUploadTmp = null;
@@ -113,7 +141,7 @@ try {
         $checkoutCursoId = (int)($_POST['id_curso'] ?? 0);
 
         try {
-            $usuarioId = (int)($_SESSION['id_usuario'] ?? 0);
+            $usuarioId = obtener_usuario_id_de_sesion();
             if ($usuarioId <= 0) {
                 throw new RuntimeException('Debés iniciar sesión para completar la solicitud.');
             }
@@ -490,7 +518,7 @@ try {
             if (!$certificacionRow) {
                 throw new RuntimeException('No encontramos la solicitud de certificación.');
             }
-            $usuarioId = (int)($_SESSION['id_usuario'] ?? 0);
+            $usuarioId = obtener_usuario_id_de_sesion();
             if ($usuarioId > 0 && (int)$certificacionRow['creado_por'] !== $usuarioId) {
                 throw new RuntimeException('No tenés autorización para pagar esta certificación.');
             }

--- a/admin/procesarsbd.php
+++ b/admin/procesarsbd.php
@@ -137,11 +137,65 @@ try {
             }
             $aceptaTyC = isset($_POST['acepta_tyc']) ? 1 : 0;
 
-            if ($nombreInscrito === '' || $apellidoInscrito === '' || $emailInscrito === '' || $telefonoInscrito === '') {
-                throw new InvalidArgumentException('Completá los datos obligatorios de contacto.');
+            if (isset($_SESSION['usuario']) && is_array($_SESSION['usuario'])) {
+                $usuarioSesion = $_SESSION['usuario'];
+                if ($nombreInscrito === '' && !empty($usuarioSesion['nombre'])) {
+                    $nombreInscrito = trim((string)$usuarioSesion['nombre']);
+                }
+                if ($apellidoInscrito === '' && !empty($usuarioSesion['apellido'])) {
+                    $apellidoInscrito = trim((string)$usuarioSesion['apellido']);
+                }
+                if ($emailInscrito === '' && !empty($usuarioSesion['email'])) {
+                    $emailInscrito = trim((string)$usuarioSesion['email']);
+                }
+                if ($telefonoInscrito === '' && !empty($usuarioSesion['telefono'])) {
+                    $telefonoInscrito = trim((string)$usuarioSesion['telefono']);
+                }
+                if ($dniInscrito === '' && !empty($usuarioSesion['dni'])) {
+                    $dniInscrito = trim((string)$usuarioSesion['dni']);
+                }
+                if ($direccionInsc === '' && !empty($usuarioSesion['direccion'])) {
+                    $direccionInsc = trim((string)$usuarioSesion['direccion']);
+                }
+                if ($ciudadInsc === '' && !empty($usuarioSesion['ciudad'])) {
+                    $ciudadInsc = trim((string)$usuarioSesion['ciudad']);
+                }
+                if ($provinciaInsc === '' && !empty($usuarioSesion['provincia'])) {
+                    $provinciaInsc = trim((string)$usuarioSesion['provincia']);
+                }
+                if ($paisInsc === '' && !empty($usuarioSesion['pais'])) {
+                    $paisInsc = trim((string)$usuarioSesion['pais']);
+                }
+            }
+
+            if ($nombreInscrito === '' || $apellidoInscrito === '' || $emailInscrito === '') {
+                $usuarioStmt = $con->prepare('SELECT nombre, apellido, email, telefono FROM usuarios WHERE id_usuario = :id LIMIT 1');
+                $usuarioStmt->execute([':id' => $usuarioId]);
+                $usuarioRow = $usuarioStmt->fetch();
+                if ($usuarioRow) {
+                    if ($nombreInscrito === '' && !empty($usuarioRow['nombre'])) {
+                        $nombreInscrito = trim((string)$usuarioRow['nombre']);
+                    }
+                    if ($apellidoInscrito === '' && !empty($usuarioRow['apellido'])) {
+                        $apellidoInscrito = trim((string)$usuarioRow['apellido']);
+                    }
+                    if ($emailInscrito === '' && !empty($usuarioRow['email'])) {
+                        $emailInscrito = trim((string)$usuarioRow['email']);
+                    }
+                    if ($telefonoInscrito === '' && !empty($usuarioRow['telefono'])) {
+                        $telefonoInscrito = trim((string)$usuarioRow['telefono']);
+                    }
+                }
+            }
+
+            if ($nombreInscrito === '' || $apellidoInscrito === '' || $emailInscrito === '') {
+                throw new InvalidArgumentException('Completá los datos obligatorios de contacto en tu perfil para continuar.');
             }
             if (!filter_var($emailInscrito, FILTER_VALIDATE_EMAIL)) {
                 throw new InvalidArgumentException('Ingresá un correo electrónico válido.');
+            }
+            if ($telefonoInscrito === '') {
+                $telefonoInscrito = null;
             }
             if ($aceptaTyC !== 1) {
                 throw new InvalidArgumentException('Debés aceptar los Términos y Condiciones.');

--- a/admin/procesarsbd.php
+++ b/admin/procesarsbd.php
@@ -64,6 +64,18 @@ function parse_dt_local(string $v): string
     return $dt->format('Y-m-d H:i:s');
 }
 
+function registrar_historico_certificacion(PDO $con, int $idCertificacion, int $estado): void
+{
+    $hist = $con->prepare('
+        INSERT INTO historico_estado_certificaciones (id_certificacion, id_estado)
+        VALUES (:id, :estado)
+    ');
+    $hist->execute([
+        ':id' => $idCertificacion,
+        ':estado' => $estado,
+    ]);
+}
+
 /* =================== MAIN FLOW ================== */
 $checkoutUploadAbs = null;
 $checkoutUploadTmp = null;
@@ -86,7 +98,263 @@ try {
     // Fallback para acciones cuando el submit se hace por JS
     $accion = $_POST['__accion'] ?? '';
 
+    $isCrearCertificacion = ($accion === 'crear_certificacion');
+    $isAprobarCertificacion = ($accion === 'aprobar_certificacion');
+    $isRechazarCertificacion = ($accion === 'rechazar_certificacion');
+
     $checkoutIsCrearOrden = isset($_POST['crear_orden']) || ($accion === 'crear_orden');
+
+    if ($isCrearCertificacion) {
+        $certUploadTmp = null;
+        $certUploadAbs = null;
+        $certUploadRel = null;
+        $certUploadMoved = false;
+        $certUploadOld = null;
+        $checkoutCursoId = (int)($_POST['id_curso'] ?? 0);
+
+        try {
+            $usuarioId = (int)($_SESSION['id_usuario'] ?? 0);
+            if ($usuarioId <= 0) {
+                throw new RuntimeException('Debés iniciar sesión para completar la solicitud.');
+            }
+
+            if ($checkoutCursoId <= 0) {
+                throw new InvalidArgumentException('Curso inválido.');
+            }
+
+            $certificacionId = (int)($_POST['id_certificacion'] ?? 0);
+            $nombreInscrito  = trim((string)($_POST['nombre_insc'] ?? ''));
+            $apellidoInscrito = trim((string)($_POST['apellido_insc'] ?? ''));
+            $emailInscrito   = trim((string)($_POST['email_insc'] ?? ''));
+            $telefonoInscrito = trim((string)($_POST['tel_insc'] ?? ''));
+            $dniInscrito     = trim((string)($_POST['dni_insc'] ?? ''));
+            $direccionInsc   = trim((string)($_POST['dir_insc'] ?? ''));
+            $ciudadInsc      = trim((string)($_POST['ciu_insc'] ?? ''));
+            $provinciaInsc   = trim((string)($_POST['prov_insc'] ?? ''));
+            $paisInsc        = trim((string)($_POST['pais_insc'] ?? ''));
+            if ($paisInsc === '') {
+                $paisInsc = 'Argentina';
+            }
+            $aceptaTyC = isset($_POST['acepta_tyc']) ? 1 : 0;
+
+            if ($nombreInscrito === '' || $apellidoInscrito === '' || $emailInscrito === '' || $telefonoInscrito === '') {
+                throw new InvalidArgumentException('Completá los datos obligatorios de contacto.');
+            }
+            if (!filter_var($emailInscrito, FILTER_VALIDATE_EMAIL)) {
+                throw new InvalidArgumentException('Ingresá un correo electrónico válido.');
+            }
+            if ($aceptaTyC !== 1) {
+                throw new InvalidArgumentException('Debés aceptar los Términos y Condiciones.');
+            }
+
+            $cursoStmt = $con->prepare('SELECT id_curso, nombre_curso FROM cursos WHERE id_curso = :id LIMIT 1');
+            $cursoStmt->execute([':id' => $checkoutCursoId]);
+            $cursoRow = $cursoStmt->fetch();
+            if (!$cursoRow) {
+                throw new RuntimeException('No encontramos la certificación seleccionada.');
+            }
+
+            $precioStmt = $con->prepare('
+              SELECT precio, moneda
+                FROM curso_precio_hist
+               WHERE id_curso = :c
+                 AND vigente_desde <= NOW()
+                 AND (vigente_hasta IS NULL OR vigente_hasta > NOW())
+            ORDER BY vigente_desde DESC
+               LIMIT 1
+            ');
+            $precioStmt->execute([':c' => $checkoutCursoId]);
+            $precioRow = $precioStmt->fetch();
+            $precioFinal = $precioRow ? (float)$precioRow['precio'] : (float)($_POST['precio_checkout'] ?? 0.0);
+            if ($precioFinal < 0) {
+                $precioFinal = 0.0;
+            }
+            $monedaPrecio = ($precioRow && !empty($precioRow['moneda'])) ? (string)$precioRow['moneda'] : 'ARS';
+
+            $certificacionRow = null;
+            if ($certificacionId > 0) {
+                $certStmt = $con->prepare('SELECT * FROM checkout_certificaciones WHERE id_certificacion = :id LIMIT 1');
+                $certStmt->execute([':id' => $certificacionId]);
+                $certificacionRow = $certStmt->fetch();
+                if (!$certificacionRow || (int)$certificacionRow['creado_por'] !== $usuarioId || (int)$certificacionRow['id_curso'] !== $checkoutCursoId) {
+                    throw new RuntimeException('No encontramos la solicitud de certificación para actualizar.');
+                }
+                $estadoActual = (int)$certificacionRow['id_estado'];
+                if (!in_array($estadoActual, [1, 4], true)) {
+                    throw new RuntimeException('Esta certificación ya fue procesada y no puede modificarse.');
+                }
+                $certUploadOld = $certificacionRow['pdf_path'] ?? null;
+            }
+
+            $archivoPdf = $_FILES['cert_pdf'] ?? null;
+            if (!is_array($archivoPdf) || ($archivoPdf['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+                throw new InvalidArgumentException('Debés adjuntar el formulario firmado en PDF.');
+            }
+
+            $certUploadTmp = (string)$archivoPdf['tmp_name'];
+            if ($certUploadTmp === '' || !is_uploaded_file($certUploadTmp)) {
+                throw new RuntimeException('No pudimos procesar el archivo subido.');
+            }
+            $certTamano = (int)$archivoPdf['size'];
+            $certMax = 10 * 1024 * 1024;
+            if ($certTamano > $certMax) {
+                throw new InvalidArgumentException('El PDF supera el tamaño máximo permitido (10 MB).');
+            }
+
+            $mimeDetectado = '';
+            if (class_exists('finfo')) {
+                $finfo = new finfo(FILEINFO_MIME_TYPE);
+                if ($finfo) {
+                    $mimeDetectado = (string)$finfo->file($certUploadTmp);
+                }
+            }
+            if ($mimeDetectado === '' && function_exists('mime_content_type')) {
+                $mimeDetectado = (string)@mime_content_type($certUploadTmp);
+            }
+            if ($mimeDetectado === '') {
+                $mimeDetectado = 'application/pdf';
+            }
+            if ($mimeDetectado !== 'application/pdf') {
+                throw new InvalidArgumentException('El formulario debe estar en formato PDF.');
+            }
+
+            $uploadsBase = __DIR__ . '/../uploads/certificaciones';
+            if (!is_dir($uploadsBase)) {
+                if (!mkdir($uploadsBase, 0755, true) && !is_dir($uploadsBase)) {
+                    throw new RuntimeException('No se pudo crear la carpeta para almacenar los formularios.');
+                }
+            }
+
+            $nombreArchivo = 'cert_' . date('YmdHis') . '_' . bin2hex(random_bytes(8)) . '.pdf';
+            $certUploadAbs = $uploadsBase . '/' . $nombreArchivo;
+            $certUploadRel = 'uploads/certificaciones/' . $nombreArchivo;
+            $pdfNombreOriginal = (string)$archivoPdf['name'];
+
+            $con->beginTransaction();
+
+            if ($certificacionRow) {
+                $observacionesBase = 'Formulario reenviado el ' . date('d/m/Y H:i');
+                $observacionesExistentes = trim((string)($certificacionRow['observaciones'] ?? ''));
+                if ($observacionesExistentes !== '') {
+                    $observacionesBase .= ' | ' . $observacionesExistentes;
+                }
+                $update = $con->prepare('
+                    UPDATE checkout_certificaciones
+                       SET nombre = :nombre,
+                           apellido = :apellido,
+                           email = :email,
+                           telefono = :telefono,
+                           acepta_tyc = :acepta,
+                           precio_total = :precio,
+                           moneda = :moneda,
+                           pdf_path = :pdf_path,
+                           pdf_nombre = :pdf_nombre,
+                           pdf_mime = :pdf_mime,
+                           observaciones = :obs,
+                           id_estado = 1,
+                           dni = :dni,
+                           direccion = :direccion,
+                           ciudad = :ciudad,
+                           provincia = :provincia,
+                           pais = :pais
+                     WHERE id_certificacion = :id
+                ');
+                $update->execute([
+                    ':nombre' => $nombreInscrito,
+                    ':apellido' => $apellidoInscrito,
+                    ':email' => $emailInscrito,
+                    ':telefono' => $telefonoInscrito,
+                    ':acepta' => $aceptaTyC,
+                    ':precio' => $precioFinal,
+                    ':moneda' => strtoupper($monedaPrecio),
+                    ':pdf_path' => $certUploadRel,
+                    ':pdf_nombre' => $pdfNombreOriginal,
+                    ':pdf_mime' => 'application/pdf',
+                    ':obs' => $observacionesBase,
+                    ':dni' => $dniInscrito !== '' ? $dniInscrito : null,
+                    ':direccion' => $direccionInsc !== '' ? $direccionInsc : null,
+                    ':ciudad' => $ciudadInsc !== '' ? $ciudadInsc : null,
+                    ':provincia' => $provinciaInsc !== '' ? $provinciaInsc : null,
+                    ':pais' => $paisInsc,
+                    ':id' => $certificacionId,
+                ]);
+            } else {
+                $insert = $con->prepare('
+                    INSERT INTO checkout_certificaciones (
+                        creado_por, acepta_tyc, precio_total, moneda, id_curso,
+                        pdf_path, pdf_nombre, pdf_mime, observaciones, id_estado,
+                        nombre, apellido, email, telefono, dni, direccion, ciudad, provincia, pais
+                    ) VALUES (
+                        :usuario, :acepta, :precio, :moneda, :curso,
+                        :pdf_path, :pdf_nombre, :pdf_mime, NULL, 1,
+                        :nombre, :apellido, :email, :telefono, :dni, :direccion, :ciudad, :provincia, :pais
+                    )
+                ');
+                $insert->execute([
+                    ':usuario' => $usuarioId,
+                    ':acepta' => $aceptaTyC,
+                    ':precio' => $precioFinal,
+                    ':moneda' => strtoupper($monedaPrecio),
+                    ':curso' => $checkoutCursoId,
+                    ':pdf_path' => $certUploadRel,
+                    ':pdf_nombre' => $pdfNombreOriginal,
+                    ':pdf_mime' => 'application/pdf',
+                    ':nombre' => $nombreInscrito,
+                    ':apellido' => $apellidoInscrito,
+                    ':email' => $emailInscrito,
+                    ':telefono' => $telefonoInscrito,
+                    ':dni' => $dniInscrito !== '' ? $dniInscrito : null,
+                    ':direccion' => $direccionInsc !== '' ? $direccionInsc : null,
+                    ':ciudad' => $ciudadInsc !== '' ? $ciudadInsc : null,
+                    ':provincia' => $provinciaInsc !== '' ? $provinciaInsc : null,
+                    ':pais' => $paisInsc,
+                ]);
+                $certificacionId = (int)$con->lastInsertId();
+            }
+
+            registrar_historico_certificacion($con, $certificacionId, 1);
+
+            if (!move_uploaded_file($certUploadTmp, $certUploadAbs)) {
+                throw new RuntimeException('No se pudo guardar el formulario de certificación.');
+            }
+            $certUploadMoved = true;
+
+            $con->commit();
+
+            if ($certUploadOld) {
+                $oldAbs = __DIR__ . '/../' . ltrim((string)$certUploadOld, '/');
+                if (is_file($oldAbs)) {
+                    @unlink($oldAbs);
+                }
+            }
+
+            $_SESSION['certificacion_success'] = [
+                'message' => '¡Solicitud enviada! Revisaremos tu documentación y te avisaremos por correo.',
+                'estado' => 1,
+                'id' => $certificacionId,
+            ];
+
+            log_cursos('checkout_crear_certificacion', [
+                'id_certificacion' => $certificacionId,
+                'id_curso' => $checkoutCursoId,
+                'usuario' => $usuarioId,
+            ]);
+
+            header('Location: ../checkout/checkout.php?id_certificacion=' . $checkoutCursoId . '&tipo=certificacion');
+            exit;
+        } catch (Throwable $certException) {
+            if ($con->inTransaction()) {
+                $con->rollBack();
+            }
+            if ($certUploadMoved && $certUploadAbs && is_file($certUploadAbs)) {
+                @unlink($certUploadAbs);
+            }
+            $_SESSION['certificacion_error'] = ['message' => $certException->getMessage()];
+            $fallbackCurso = $checkoutCursoId > 0 ? $checkoutCursoId : 0;
+            header('Location: ../checkout/checkout.php?id_certificacion=' . $fallbackCurso . '&tipo=certificacion');
+            exit;
+        }
+    }
 
     if ($checkoutIsCrearOrden) {
         $checkoutCursoId = (int)($_POST['id_curso'] ?? 0);
@@ -124,6 +392,8 @@ try {
             $observacionesPago = substr($obsPagoRaw, 0, 250);
         }
         $precioInput = isset($_POST['precio_checkout']) ? (float)$_POST['precio_checkout'] : 0.0;
+        $certificacionId = (int)($_POST['id_certificacion'] ?? 0);
+        $certificacionRow = null;
 
         if ($checkoutCursoId <= 0) {
             throw new InvalidArgumentException('Curso inválido.');
@@ -140,6 +410,29 @@ try {
         $metodosPermitidos = ['transferencia', 'mercado_pago'];
         if (!in_array($metodoPago, $metodosPermitidos, true)) {
             throw new InvalidArgumentException('Método de pago inválido.');
+        }
+
+        if ($checkoutTipo === 'certificacion') {
+            if ($certificacionId <= 0) {
+                throw new RuntimeException('Necesitamos una certificación aprobada para continuar con el pago.');
+            }
+            $certStmt = $con->prepare('SELECT * FROM checkout_certificaciones WHERE id_certificacion = :id LIMIT 1');
+            $certStmt->execute([':id' => $certificacionId]);
+            $certificacionRow = $certStmt->fetch();
+            if (!$certificacionRow) {
+                throw new RuntimeException('No encontramos la solicitud de certificación.');
+            }
+            $usuarioId = (int)($_SESSION['id_usuario'] ?? 0);
+            if ($usuarioId > 0 && (int)$certificacionRow['creado_por'] !== $usuarioId) {
+                throw new RuntimeException('No tenés autorización para pagar esta certificación.');
+            }
+            $estadoCert = (int)$certificacionRow['id_estado'];
+            if ($estadoCert === 3) {
+                throw new RuntimeException('La certificación ya registra un pago.');
+            }
+            if ($estadoCert !== 2) {
+                throw new RuntimeException('Debés esperar la aprobación de la certificación antes de continuar con el pago.');
+            }
         }
 
         $cursoStmt = $con->prepare("SELECT id_curso, nombre_curso FROM cursos WHERE id_curso = :id LIMIT 1");
@@ -277,6 +570,48 @@ try {
             ':obs' => $observacionesPago !== '' ? $observacionesPago : null,
         ]);
 
+        if ($checkoutTipo === 'certificacion' && $certificacionRow) {
+            $observacionesCert = 'Pago iniciado por ' . ($metodoPago === 'mercado_pago' ? 'Mercado Pago' : 'transferencia bancaria') . ' el ' . date('d/m/Y H:i');
+            $observacionesExistentes = trim((string)($certificacionRow['observaciones'] ?? ''));
+            if ($observacionesExistentes !== '') {
+                $observacionesCert .= ' | ' . $observacionesExistentes;
+            }
+            $upCert = $con->prepare('
+                UPDATE checkout_certificaciones
+                   SET id_estado = 3,
+                       precio_total = :precio,
+                       moneda = :moneda,
+                       observaciones = :obs,
+                       nombre = :nombre,
+                       apellido = :apellido,
+                       email = :email,
+                       telefono = :telefono,
+                       dni = :dni,
+                       direccion = :direccion,
+                       ciudad = :ciudad,
+                       provincia = :provincia,
+                       pais = :pais,
+                       acepta_tyc = 1
+                 WHERE id_certificacion = :id
+            ');
+            $upCert->execute([
+                ':precio' => $precioFinal,
+                ':moneda' => $monedaPrecio,
+                ':obs' => $observacionesCert,
+                ':nombre' => $nombreInscrito,
+                ':apellido' => $apellidoInscrito,
+                ':email' => $emailInscrito,
+                ':telefono' => $telefonoInscrito,
+                ':dni' => $dniInscrito !== '' ? $dniInscrito : null,
+                ':direccion' => $direccionInsc !== '' ? $direccionInsc : null,
+                ':ciudad' => $ciudadInsc !== '' ? $ciudadInsc : null,
+                ':provincia' => $provinciaInsc !== '' ? $provinciaInsc : null,
+                ':pais' => $paisInsc,
+                ':id' => (int)$certificacionRow['id_certificacion'],
+            ]);
+            registrar_historico_certificacion($con, (int)$certificacionRow['id_certificacion'], 3);
+        }
+
         if ($metodoPago === 'transferencia' && $checkoutUploadAbs !== null) {
             if (!move_uploaded_file($checkoutUploadTmp, $checkoutUploadAbs)) {
                 throw new RuntimeException('No se pudo guardar el comprobante de la transferencia.');
@@ -311,6 +646,49 @@ try {
         $redirectUrl = '../checkout/gracias.php?' . http_build_query($redirectQuery);
 
         header('Location: ' . $redirectUrl);
+        exit;
+    }
+
+    if ($isAprobarCertificacion || $isRechazarCertificacion) {
+        $certificacionId = (int)($_POST['id_certificacion'] ?? 0);
+        $motivo = trim((string)($_POST['motivo'] ?? ''));
+        if ($certificacionId <= 0) {
+            throw new InvalidArgumentException('Certificación inválida.');
+        }
+
+        $certStmt = $con->prepare('SELECT * FROM checkout_certificaciones WHERE id_certificacion = :id LIMIT 1');
+        $certStmt->execute([':id' => $certificacionId]);
+        $certRow = $certStmt->fetch();
+        if (!$certRow) {
+            throw new RuntimeException('No encontramos la certificación seleccionada.');
+        }
+
+        $nuevoEstado = $isAprobarCertificacion ? 2 : 4;
+        $notaBase = $isAprobarCertificacion ? 'Solicitud aprobada el ' : 'Solicitud rechazada el ';
+        $observaciones = $notaBase . date('d/m/Y H:i');
+        if ($motivo !== '') {
+            $observaciones .= ' - ' . $motivo;
+        }
+        $observacionesPrevias = trim((string)($certRow['observaciones'] ?? ''));
+        if ($observacionesPrevias !== '') {
+            $observaciones .= ' | ' . $observacionesPrevias;
+        }
+
+        $con->beginTransaction();
+        $upCert = $con->prepare('UPDATE checkout_certificaciones SET id_estado = :estado, observaciones = :obs WHERE id_certificacion = :id');
+        $upCert->execute([
+            ':estado' => $nuevoEstado,
+            ':obs' => $observaciones,
+            ':id' => $certificacionId,
+        ]);
+        registrar_historico_certificacion($con, $certificacionId, $nuevoEstado);
+        $con->commit();
+
+        $_SESSION['certificacion_admin_success'] = $isAprobarCertificacion
+            ? 'La certificación fue aprobada correctamente.'
+            : 'La certificación fue rechazada correctamente.';
+
+        header('Location: certificaciones.php');
         exit;
     }
 
@@ -675,6 +1053,12 @@ try {
             $redirect .= '?' . http_build_query($params);
         }
         header('Location: ' . $redirect);
+        exit;
+    }
+
+    if ($isAprobarCertificacion || $isRechazarCertificacion) {
+        $_SESSION['certificacion_admin_error'] = $e->getMessage();
+        header('Location: certificaciones.php');
         exit;
     }
 

--- a/assets/pdf/solicitud_certificacion.pdf
+++ b/assets/pdf/solicitud_certificacion.pdf
@@ -1,0 +1,39 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 96 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Solicitud de Certificación) Tj
+/F1 14 Tf
+0 -40 Td
+(Complete y envíe este formulario con la información solicitada.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000115 00000 n 
+0000000256 00000 n 
+0000000383 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+465
+%%EOF

--- a/certificacion.php
+++ b/certificacion.php
@@ -167,7 +167,7 @@ $modalidad_nombres_str = implode(' - ', $modalidad_nombres);
                             </div>
                         </div>
 
-                        <a class="enroll-button" href="checkout/checkout.php?id_curso=<?php echo isset($cert['id_curso']) ? (int)$cert['id_curso'] : 0; ?>">
+                        <a class="enroll-button" href="checkout/checkout.php?id_certificacion=<?php echo isset($cert['id_curso']) ? (int)$cert['id_curso'] : 0; ?>&tipo=certificacion">
                             <i class="fa-solid fa-paper-plane me-2"></i> Solicitar certificación
                         </a>
                     </div>

--- a/checkout/checkout.php
+++ b/checkout/checkout.php
@@ -376,70 +376,37 @@ include '../head.php';
                                     </div>
 
                                     <div class="step-panel" data-step="2">
-                                        <div class="row g-3">
-                                            <div class="col-md-6">
-                                                <label for="nombre" class="form-label required-field">Nombre</label>
-                                                <input type="text" class="form-control" id="nombre" name="nombre_insc" placeholder="Nombre" autocomplete="given-name" value="<?php echo h($prefillNombre); ?>">
-                                            </div>
-                                            <div class="col-md-6">
-                                                <label for="apellido" class="form-label required-field">Apellido</label>
-                                                <input type="text" class="form-control" id="apellido" name="apellido_insc" placeholder="Apellido" autocomplete="family-name" value="<?php echo h($prefillApellido); ?>">
-                                            </div>
-                                            <div class="col-md-6">
-                                                <label for="email" class="form-label required-field">Email</label>
-                                                <input type="email" class="form-control" id="email" name="email_insc" placeholder="correo@dominio.com" autocomplete="email" value="<?php echo h($prefillEmail); ?>">
-                                            </div>
-                                            <div class="col-md-6">
-                                                <label for="telefono" class="form-label required-field">Teléfono</label>
-                                                <input type="text" class="form-control" id="telefono" name="tel_insc" placeholder="+54 11 5555-5555" autocomplete="tel" value="<?php echo h($prefillTelefono); ?>">
-                                            </div>
-                                            <div class="col-md-4">
-                                                <label for="dni" class="form-label">DNI</label>
-                                                <input type="text" class="form-control" id="dni" name="dni_insc" placeholder="Documento" value="<?php echo h($certificacionData['dni'] ?? $prefillDni); ?>">
-                                            </div>
-                                            <div class="col-md-8">
-                                                <label for="direccion" class="form-label">Dirección</label>
-                                                <input type="text" class="form-control" id="direccion" name="dir_insc" placeholder="Calle y número" autocomplete="address-line1" value="<?php echo h($certificacionData['direccion'] ?? $prefillDireccion); ?>">
-                                            </div>
-                                            <div class="col-md-4">
-                                                <label for="ciudad" class="form-label">Ciudad</label>
-                                                <input type="text" class="form-control" id="ciudad" name="ciu_insc" autocomplete="address-level2" value="<?php echo h($certificacionData['ciudad'] ?? $prefillCiudad); ?>">
-                                            </div>
-                                            <div class="col-md-4">
-                                                <label for="provincia" class="form-label">Provincia</label>
-                                                <input type="text" class="form-control" id="provincia" name="prov_insc" autocomplete="address-level1" value="<?php echo h($certificacionData['provincia'] ?? $prefillProvincia); ?>">
-                                            </div>
-                                            <div class="col-md-4">
-                                                <label for="pais" class="form-label">País</label>
-                                                <input type="text" class="form-control" id="pais" name="pais_insc" value="<?php echo h($certificacionData['pais'] ?? $prefillPais); ?>" autocomplete="country-name">
-                                            </div>
-                                        </div>
-                                        <div class="terms-check mt-4">
-                                            <input type="checkbox" class="form-check-input mt-1" id="acepta" name="acepta_tyc" value="1" <?php echo (!empty($certificacionData) && (int)$certificacionData['acepta_tyc'] === 1) ? 'checked' : ''; ?>>
-                                            <label class="form-check-label" for="acepta">
-                                                Confirmo que los datos ingresados son correctos y acepto los <a href="#" target="_blank" rel="noopener">Términos y Condiciones</a>.
-                                            </label>
-                                        </div>
                                         <?php if ($tipo_checkout === 'certificacion'): ?>
-                                            <div class="certificacion-status mt-4">
-                                                <?php if ($certificacionEstado !== null): ?>
-                                                    <div class="alert alert-info checkout-alert mb-3" role="alert">
-                                                        <div class="d-flex align-items-start gap-2">
-                                                            <i class="fas fa-info-circle mt-1"></i>
-                                                            <div>
-                                                                <strong>Estado de tu solicitud:</strong>
-                                                                <div class="small mt-1"><?php echo h(checkout_certificacion_estado_label($certificacionEstado)); ?>.</div>
-                                                                <?php if (!empty($certificacionData['observaciones'])): ?>
-                                                                    <div class="small text-muted mt-1"><?php echo nl2br(h($certificacionData['observaciones'])); ?></div>
-                                                                <?php endif; ?>
-                                                            </div>
+                                            <input type="hidden" name="nombre_insc" value="<?php echo h($certificacionData['nombre'] ?? $prefillNombre); ?>">
+                                            <input type="hidden" name="apellido_insc" value="<?php echo h($certificacionData['apellido'] ?? $prefillApellido); ?>">
+                                            <input type="hidden" name="email_insc" value="<?php echo h($certificacionData['email'] ?? $prefillEmail); ?>">
+                                            <input type="hidden" name="tel_insc" value="<?php echo h($certificacionData['telefono'] ?? $prefillTelefono); ?>">
+                                            <input type="hidden" name="dni_insc" value="<?php echo h($certificacionData['dni'] ?? $prefillDni); ?>">
+                                            <input type="hidden" name="dir_insc" value="<?php echo h($certificacionData['direccion'] ?? $prefillDireccion); ?>">
+                                            <input type="hidden" name="ciu_insc" value="<?php echo h($certificacionData['ciudad'] ?? $prefillCiudad); ?>">
+                                            <input type="hidden" name="prov_insc" value="<?php echo h($certificacionData['provincia'] ?? $prefillProvincia); ?>">
+                                            <input type="hidden" name="pais_insc" value="<?php echo h($certificacionData['pais'] ?? $prefillPais); ?>">
+
+                                            <?php if ($certificacionEstado !== null): ?>
+                                                <div class="alert alert-info checkout-alert mb-4" role="alert">
+                                                    <div class="d-flex align-items-start gap-2">
+                                                        <i class="fas fa-info-circle mt-1"></i>
+                                                        <div>
+                                                            <strong>Estado de tu solicitud:</strong>
+                                                            <div class="small mt-1"><?php echo h(checkout_certificacion_estado_label($certificacionEstado)); ?>.</div>
+                                                            <?php if (!empty($certificacionData['observaciones'])): ?>
+                                                                <div class="small text-muted mt-1"><?php echo nl2br(h($certificacionData['observaciones'])); ?></div>
+                                                            <?php endif; ?>
                                                         </div>
                                                     </div>
-                                                <?php endif; ?>
-                                                <div class="documentacion-card">
-                                                    <div class="summary-card">
+                                                </div>
+                                            <?php endif; ?>
+
+                                            <div class="row g-4 align-items-stretch">
+                                                <div class="col-lg-7">
+                                                    <div class="summary-card h-100">
                                                         <h5>Documentación requerida</h5>
-                                                        <p class="mb-2">Descargá, completá y cargá el formulario en PDF para que nuestro equipo lo revise.</p>
+                                                        <p class="mb-3">Descargá el formulario, completalo y volvé a subirlo en formato PDF para que nuestro equipo pueda revisarlo.</p>
                                                         <a class="btn btn-outline-light btn-sm mb-3" href="../assets/pdf/solicitud_certificacion.pdf" target="_blank" rel="noopener">
                                                             <i class="fas fa-file-download me-2"></i>Descargar formulario
                                                         </a>
@@ -454,7 +421,45 @@ include '../head.php';
                                                         <div class="upload-label">Formato requerido: PDF. Tamaño máximo 10 MB.</div>
                                                     </div>
                                                 </div>
+                                                <div class="col-lg-5">
+                                                    <div class="summary-card h-100">
+                                                        <h5>Datos del solicitante</h5>
+                                                        <p class="mb-3 small text-muted">Utilizaremos estos datos de tu perfil para validar tu certificación.</p>
+                                                        <?php
+                                                        $nombreMostrar = $certificacionData['nombre'] ?? $prefillNombre;
+                                                        $apellidoMostrar = $certificacionData['apellido'] ?? $prefillApellido;
+                                                        $emailMostrar = $certificacionData['email'] ?? $prefillEmail;
+                                                        $telefonoMostrar = $certificacionData['telefono'] ?? $prefillTelefono;
+                                                        ?>
+                                                        <ul class="list-unstyled mb-0">
+                                                            <li><strong>Nombre:</strong> <?php echo h($nombreMostrar); ?> <?php echo h($apellidoMostrar); ?></li>
+                                                            <li><strong>Email:</strong> <?php echo h($emailMostrar); ?></li>
+                                                            <li><strong>Teléfono:</strong> <?php echo $telefonoMostrar ? h($telefonoMostrar) : 'No informado'; ?></li>
+                                                            <?php if ($prefillDni || (!empty($certificacionData['dni']))): ?>
+                                                                <li><strong>DNI:</strong> <?php echo h($certificacionData['dni'] ?? $prefillDni); ?></li>
+                                                            <?php endif; ?>
+                                                            <?php if ($prefillDireccion || (!empty($certificacionData['direccion']))): ?>
+                                                                <li><strong>Dirección:</strong> <?php echo h($certificacionData['direccion'] ?? $prefillDireccion); ?></li>
+                                                            <?php endif; ?>
+                                                            <?php if ($prefillCiudad || (!empty($certificacionData['ciudad']))): ?>
+                                                                <li><strong>Ciudad:</strong> <?php echo h($certificacionData['ciudad'] ?? $prefillCiudad); ?></li>
+                                                            <?php endif; ?>
+                                                            <?php if ($prefillProvincia || (!empty($certificacionData['provincia']))): ?>
+                                                                <li><strong>Provincia:</strong> <?php echo h($certificacionData['provincia'] ?? $prefillProvincia); ?></li>
+                                                            <?php endif; ?>
+                                                            <li><strong>País:</strong> <?php echo h($certificacionData['pais'] ?? $prefillPais); ?></li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
                                             </div>
+
+                                            <div class="terms-check mt-4">
+                                                <input type="checkbox" class="form-check-input mt-1" id="acepta" name="acepta_tyc" value="1" <?php echo (!empty($certificacionData) && (int)$certificacionData['acepta_tyc'] === 1) ? 'checked' : ''; ?>>
+                                                <label class="form-check-label" for="acepta">
+                                                    Confirmo que la información es correcta y acepto los <a href="#" target="_blank" rel="noopener">Términos y Condiciones</a>.
+                                                </label>
+                                            </div>
+
                                             <div class="nav-actions">
                                                 <button type="button" class="btn btn-outline-light btn-rounded" data-prev="1">
                                                     <i class="fas fa-arrow-left me-2"></i>
@@ -472,6 +477,50 @@ include '../head.php';
                                                 </div>
                                             </div>
                                         <?php else: ?>
+                                            <div class="row g-3">
+                                                <div class="col-md-6">
+                                                    <label for="nombre" class="form-label required-field">Nombre</label>
+                                                    <input type="text" class="form-control" id="nombre" name="nombre_insc" placeholder="Nombre" autocomplete="given-name" value="<?php echo h($prefillNombre); ?>">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label for="apellido" class="form-label required-field">Apellido</label>
+                                                    <input type="text" class="form-control" id="apellido" name="apellido_insc" placeholder="Apellido" autocomplete="family-name" value="<?php echo h($prefillApellido); ?>">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label for="email" class="form-label required-field">Email</label>
+                                                    <input type="email" class="form-control" id="email" name="email_insc" placeholder="correo@dominio.com" autocomplete="email" value="<?php echo h($prefillEmail); ?>">
+                                                </div>
+                                                <div class="col-md-6">
+                                                    <label for="telefono" class="form-label required-field">Teléfono</label>
+                                                    <input type="text" class="form-control" id="telefono" name="tel_insc" placeholder="+54 11 5555-5555" autocomplete="tel" value="<?php echo h($prefillTelefono); ?>">
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <label for="dni" class="form-label">DNI</label>
+                                                    <input type="text" class="form-control" id="dni" name="dni_insc" placeholder="Documento" value="<?php echo h($certificacionData['dni'] ?? $prefillDni); ?>">
+                                                </div>
+                                                <div class="col-md-8">
+                                                    <label for="direccion" class="form-label">Dirección</label>
+                                                    <input type="text" class="form-control" id="direccion" name="dir_insc" placeholder="Calle y número" autocomplete="address-line1" value="<?php echo h($certificacionData['direccion'] ?? $prefillDireccion); ?>">
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <label for="ciudad" class="form-label">Ciudad</label>
+                                                    <input type="text" class="form-control" id="ciudad" name="ciu_insc" autocomplete="address-level2" value="<?php echo h($certificacionData['ciudad'] ?? $prefillCiudad); ?>">
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <label for="provincia" class="form-label">Provincia</label>
+                                                    <input type="text" class="form-control" id="provincia" name="prov_insc" autocomplete="address-level1" value="<?php echo h($certificacionData['provincia'] ?? $prefillProvincia); ?>">
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <label for="pais" class="form-label">País</label>
+                                                    <input type="text" class="form-control" id="pais" name="pais_insc" value="<?php echo h($certificacionData['pais'] ?? $prefillPais); ?>" autocomplete="country-name">
+                                                </div>
+                                            </div>
+                                            <div class="terms-check mt-4">
+                                                <input type="checkbox" class="form-check-input mt-1" id="acepta" name="acepta_tyc" value="1" <?php echo (!empty($certificacionData) && (int)$certificacionData['acepta_tyc'] === 1) ? 'checked' : ''; ?>>
+                                                <label class="form-check-label" for="acepta">
+                                                    Confirmo que los datos ingresados son correctos y acepto los <a href="#" target="_blank" rel="noopener">Términos y Condiciones</a>.
+                                                </label>
+                                            </div>
                                             <div class="nav-actions">
                                                 <button type="button" class="btn btn-outline-light btn-rounded" data-prev="1">
                                                     <i class="fas fa-arrow-left me-2"></i>
@@ -657,6 +706,15 @@ include '../head.php';
                     }
                 }
                 if (step === 2) {
+                    if (checkoutType === 'certificacion') {
+                        const terms = document.getElementById('acepta');
+                        if (!terms || !terms.checked) {
+                            goToStep(2);
+                            showAlert('warning', 'Términos y Condiciones', 'Debés aceptar los Términos y Condiciones para continuar.');
+                            return false;
+                        }
+                        return true;
+                    }
                     const required = [
                         { id: 'nombre', label: 'Nombre' },
                         { id: 'apellido', label: 'Apellido' },
@@ -672,7 +730,8 @@ include '../head.php';
                         showAlert('error', 'Faltan datos', `Completá el campo <strong>${missing.label}</strong> para continuar.`);
                         return false;
                     }
-                    const email = document.getElementById('email').value.trim();
+                    const emailInput = document.getElementById('email');
+                    const email = emailInput ? emailInput.value.trim() : '';
                     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
                     if (!emailPattern.test(email)) {
                         goToStep(2);
@@ -680,7 +739,7 @@ include '../head.php';
                         return false;
                     }
                     const terms = document.getElementById('acepta');
-                    if (!terms.checked) {
+                    if (!terms || !terms.checked) {
                         goToStep(2);
                         showAlert('warning', 'Términos y Condiciones', 'Debés aceptar los Términos y Condiciones para continuar.');
                         return false;

--- a/checkout/gracias_certificacion.php
+++ b/checkout/gracias_certificacion.php
@@ -1,0 +1,209 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+require_once __DIR__ . '/../sbd.php';
+require_once __DIR__ . '/mercadopago_mailer.php';
+
+$page_title = 'Solicitud de certificación enviada | Instituto de Formación';
+$page_description = 'Confirmación del envío de la documentación para certificaciones.';
+$base_path = '../';
+
+$flashData = $_SESSION['certificacion_gracias'] ?? null;
+if ($flashData !== null) {
+    unset($_SESSION['certificacion_gracias']);
+}
+
+$certificacionId = isset($_GET['certificacion']) ? (int) $_GET['certificacion'] : 0;
+$data = null;
+$error = null;
+
+if (is_array($flashData) && !empty($flashData)) {
+    $data = $flashData;
+}
+
+if (!$data && $certificacionId > 0) {
+    try {
+        if (!isset($con) || !($con instanceof PDO)) {
+            throw new RuntimeException('No se pudo conectar con la base de datos.');
+        }
+        $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $con->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $st = $con->prepare('
+            SELECT cc.id_certificacion, cc.id_curso, cc.nombre, cc.apellido, cc.email, cc.telefono,
+                   cc.precio_total, cc.moneda, cc.id_estado, c.nombre_curso, c.nombre_certificacion
+              FROM checkout_certificaciones cc
+         LEFT JOIN cursos c ON c.id_curso = cc.id_curso
+             WHERE cc.id_certificacion = :id
+             LIMIT 1
+        ');
+        $st->execute([':id' => $certificacionId]);
+        $row = $st->fetch();
+        if (!$row) {
+            throw new RuntimeException('No encontramos la solicitud de certificación.');
+        }
+        $data = [
+            'id_certificacion' => (int) $row['id_certificacion'],
+            'id_curso' => (int) $row['id_curso'],
+            'curso_nombre' => (string) ($row['nombre_certificacion'] ?? $row['nombre_curso'] ?? ''),
+            'nombre' => (string) ($row['nombre'] ?? ''),
+            'apellido' => (string) ($row['apellido'] ?? ''),
+            'email' => (string) ($row['email'] ?? ''),
+            'telefono' => (string) ($row['telefono'] ?? ''),
+            'precio' => isset($row['precio_total']) ? (float) $row['precio_total'] : null,
+            'moneda' => (string) ($row['moneda'] ?? 'ARS'),
+            'estado' => isset($row['id_estado']) ? (int) $row['id_estado'] : null,
+        ];
+    } catch (Throwable $exception) {
+        $error = $exception->getMessage();
+    }
+}
+
+function cert_estado_label(?int $estado): string
+{
+    return match ($estado) {
+        2 => 'Documentación aprobada',
+        3 => 'Pago registrado',
+        4 => 'Solicitud rechazada',
+        default => 'En revisión',
+    };
+}
+
+$viewData = is_array($data) ? $data : [];
+if (!$viewData && !$error) {
+    $error = 'No encontramos la solicitud de certificación para mostrar.';
+}
+
+$nombreCurso = $viewData['curso_nombre'] ?? '';
+$nombreSolicitante = trim(($viewData['nombre'] ?? '') . ' ' . ($viewData['apellido'] ?? ''));
+$estadoActual = cert_estado_label($viewData['estado'] ?? null);
+$precioCert = $viewData['precio'] ?? null;
+$monedaCert = $viewData['moneda'] ?? 'ARS';
+$checkoutLink = null;
+if (!empty($viewData['id_curso'])) {
+    $checkoutLink = sprintf('checkout.php?id_certificacion=%d&tipo=certificacion', (int) $viewData['id_curso']);
+}
+$backLink = '../index.php#certificaciones';
+
+?>
+<!DOCTYPE html>
+<html lang="es">
+<?php include __DIR__ . '/../head.php'; ?>
+<body class="checkout-body">
+<?php include __DIR__ . '/../nav.php'; ?>
+
+<main class="checkout-main">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-xl-8">
+                <div class="checkout-card">
+                    <div class="checkout-header">
+                        <h1>¡Gracias por enviar tu solicitud!</h1>
+                        <p>Recibimos tu documentación y comenzaremos la revisión.</p>
+                    </div>
+                    <div class="checkout-content">
+                        <?php if ($error): ?>
+                            <div class="alert alert-danger checkout-alert" role="alert">
+                                <div class="d-flex align-items-start gap-2">
+                                    <i class="fas fa-triangle-exclamation mt-1"></i>
+                                    <div>
+                                        <strong>No pudimos recuperar tu solicitud.</strong>
+                                        <div class="small mt-1"><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+                                        <div class="small mt-1">Si necesitás ayuda, escribinos a <a href="mailto:<?php echo htmlspecialchars(checkout_mail_config()['admin_email'], ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars(checkout_mail_config()['admin_email'], ENT_QUOTES, 'UTF-8'); ?></a>.</div>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php else: ?>
+                            <div class="alert alert-success checkout-alert" role="alert">
+                                <div class="d-flex align-items-start gap-2">
+                                    <i class="fas fa-circle-check mt-1"></i>
+                                    <div>
+                                        <strong>Tu documentación está en revisión.</strong>
+                                        <div class="small mt-1">Nuestro equipo verificará el formulario y te notificará por correo apenas tengamos novedades.</div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <section class="mb-4">
+                                <h2 class="h5 fw-bold mb-3">Resumen de tu solicitud</h2>
+                                <div class="card border-0 shadow-sm">
+                                    <div class="card-body">
+                                        <div class="mb-2">
+                                            <span class="text-muted d-block small">Certificación</span>
+                                            <span class="fw-semibold"><?php echo htmlspecialchars($nombreCurso !== '' ? $nombreCurso : 'Certificación solicitada', ENT_QUOTES, 'UTF-8'); ?></span>
+                                        </div>
+                                        <div class="mb-2">
+                                            <span class="text-muted d-block small">Solicitante</span>
+                                            <span class="fw-semibold"><?php echo htmlspecialchars($nombreSolicitante !== '' ? $nombreSolicitante : 'Datos registrados en tu perfil', ENT_QUOTES, 'UTF-8'); ?></span>
+                                        </div>
+                                        <div class="mb-2">
+                                            <span class="text-muted d-block small">Contacto</span>
+                                            <span class="fw-semibold"><?php echo htmlspecialchars($viewData['email'] ?? 'Te escribiremos al correo registrado', ENT_QUOTES, 'UTF-8'); ?></span>
+                                            <?php if (!empty($viewData['telefono'])): ?>
+                                                <div class="small text-muted">Teléfono: <?php echo htmlspecialchars($viewData['telefono'], ENT_QUOTES, 'UTF-8'); ?></div>
+                                            <?php endif; ?>
+                                        </div>
+                                        <div class="mb-0">
+                                            <span class="text-muted d-block small">Estado actual</span>
+                                            <span class="badge bg-primary-subtle text-primary-emphasis px-3 py-2"><?php echo htmlspecialchars($estadoActual, ENT_QUOTES, 'UTF-8'); ?></span>
+                                            <?php if ($precioCert !== null): ?>
+                                                <div class="small text-muted mt-2">Inversión estimada: <?php echo htmlspecialchars(number_format((float) $precioCert, 2, ',', '.'), ENT_QUOTES, 'UTF-8'); ?> <?php echo htmlspecialchars($monedaCert, ENT_QUOTES, 'UTF-8'); ?></div>
+                                            <?php endif; ?>
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
+
+                            <section class="mb-4">
+                                <h2 class="h5 fw-bold mb-3">¿Qué sucede ahora?</h2>
+                                <ul class="list-unstyled timeline-list">
+                                    <li class="d-flex mb-3">
+                                        <i class="fas fa-file-circle-check text-primary me-3 mt-1"></i>
+                                        <div>
+                                            <strong>Revisión de tu formulario</strong>
+                                            <p class="mb-0 small text-muted">Verificaremos que la documentación esté completa y cumpla con los requisitos.</p>
+                                        </div>
+                                    </li>
+                                    <li class="d-flex mb-3">
+                                        <i class="fas fa-envelope-open-text text-primary me-3 mt-1"></i>
+                                        <div>
+                                            <strong>Notificación por correo</strong>
+                                            <p class="mb-0 small text-muted">Te avisaremos si necesitamos ajustes o cuando la certificación quede aprobada para avanzar al pago.</p>
+                                        </div>
+                                    </li>
+                                    <li class="d-flex">
+                                        <i class="fas fa-credit-card text-primary me-3 mt-1"></i>
+                                        <div>
+                                            <strong>Habilitación del pago</strong>
+                                            <p class="mb-0 small text-muted">Una vez aprobada la documentación, podrás completar el último paso desde el checkout para finalizar tu certificación.</p>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </section>
+
+                            <div class="d-flex flex-column flex-md-row gap-2">
+                                <?php if ($checkoutLink): ?>
+                                    <a class="btn btn-gradient btn-rounded d-inline-flex align-items-center justify-content-center" href="<?php echo htmlspecialchars($checkoutLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                        <i class="fas fa-magnifying-glass me-2"></i>
+                                        Ver estado de mi solicitud
+                                    </a>
+                                <?php endif; ?>
+                                <a class="btn btn-outline-light btn-rounded d-inline-flex align-items-center justify-content-center" href="<?php echo htmlspecialchars($backLink, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <i class="fas fa-arrow-left me-2"></i>
+                                    Volver a las certificaciones
+                                </a>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+
+<?php include __DIR__ . '/../footer.php'; ?>
+
+</body>
+</html>

--- a/cursos.php
+++ b/cursos.php
@@ -50,7 +50,7 @@ $cursos = $sql->fetchAll(mode: PDO::FETCH_ASSOC);
             </a>
 
             <a class="btn btn-secondary btn-pill d-inline-flex align-items-center"
-              href="certificacion.php?id_curso=<?php echo urlencode($curso['id_curso']); ?>">
+              href="certificacion.php?id_certificacion=<?php echo urlencode($curso['id_curso']); ?>">
               <i class="bi bi-circle me-2"></i> Certificaci&oacute;n
             </a>
           </div>

--- a/uploads/.gitignore
+++ b/uploads/.gitignore
@@ -1,3 +1,5 @@
 *
 !.gitignore
 !comprobantes/
+!certificaciones/
+!certificaciones/**


### PR DESCRIPTION
## Summary
- add certification request handling with PDF upload and approval workflow
- update checkout flow and Mercado Pago integration to respect certification states
- introduce admin view to review, approve, or reject certification requests

## Testing
- php -l checkout/checkout.php
- php -l admin/procesarsbd.php
- php -l checkout/mercadopago_init.php
- php -l admin/certificaciones.php
- php -l admin/aside.php


------
https://chatgpt.com/codex/tasks/task_e_68dae783666083228dc09b2447ba9a0c