### PR TITLE
Actualizar checkout para nueva estructura de pagos

### DIFF
--- a/admin/procesarsbd.php
+++ b/admin/procesarsbd.php
@@ -335,12 +335,7 @@ try {
                            pdf_nombre = :pdf_nombre,
                            pdf_mime = :pdf_mime,
                            observaciones = :obs,
-                           id_estado = 1,
-                           dni = :dni,
-                           direccion = :direccion,
-                           ciudad = :ciudad,
-                           provincia = :provincia,
-                           pais = :pais
+                           id_estado = 1
                      WHERE id_certificacion = :id
                 ');
                 $update->execute([
@@ -355,11 +350,6 @@ try {
                     ':pdf_nombre' => $pdfNombreOriginal,
                     ':pdf_mime' => 'application/pdf',
                     ':obs' => $observacionesBase,
-                    ':dni' => $dniInscrito !== '' ? $dniInscrito : null,
-                    ':direccion' => $direccionInsc !== '' ? $direccionInsc : null,
-                    ':ciudad' => $ciudadInsc !== '' ? $ciudadInsc : null,
-                    ':provincia' => $provinciaInsc !== '' ? $provinciaInsc : null,
-                    ':pais' => $paisInsc,
                     ':id' => $certificacionId,
                 ]);
             } else {
@@ -367,11 +357,11 @@ try {
                     INSERT INTO checkout_certificaciones (
                         creado_por, acepta_tyc, precio_total, moneda, id_curso,
                         pdf_path, pdf_nombre, pdf_mime, observaciones, id_estado,
-                        nombre, apellido, email, telefono, dni, direccion, ciudad, provincia, pais
+                        nombre, apellido, email, telefono
                     ) VALUES (
                         :usuario, :acepta, :precio, :moneda, :curso,
                         :pdf_path, :pdf_nombre, :pdf_mime, NULL, 1,
-                        :nombre, :apellido, :email, :telefono, :dni, :direccion, :ciudad, :provincia, :pais
+                        :nombre, :apellido, :email, :telefono
                     )
                 ');
                 $insert->execute([
@@ -387,11 +377,6 @@ try {
                     ':apellido' => $apellidoInscrito,
                     ':email' => $emailInscrito,
                     ':telefono' => $telefonoInscrito,
-                    ':dni' => $dniInscrito !== '' ? $dniInscrito : null,
-                    ':direccion' => $direccionInsc !== '' ? $direccionInsc : null,
-                    ':ciudad' => $ciudadInsc !== '' ? $ciudadInsc : null,
-                    ':provincia' => $provinciaInsc !== '' ? $provinciaInsc : null,
-                    ':pais' => $paisInsc,
                 ]);
                 $certificacionId = (int)$con->lastInsertId();
             }
@@ -716,29 +701,19 @@ try {
                        apellido = :apellido,
                        email = :email,
                        telefono = :telefono,
-                       dni = :dni,
-                       direccion = :direccion,
-                       ciudad = :ciudad,
-                       provincia = :provincia,
-                       pais = :pais,
                        acepta_tyc = 1
-                 WHERE id_certificacion = :id
-            ');
-            $upCert->execute([
-                ':precio' => $precioFinal,
-                ':moneda' => $monedaPrecio,
-                ':obs' => $observacionesCert,
-                ':nombre' => $nombreInscrito,
-                ':apellido' => $apellidoInscrito,
-                ':email' => $emailInscrito,
-                ':telefono' => $telefonoInscrito,
-                ':dni' => $dniInscrito !== '' ? $dniInscrito : null,
-                ':direccion' => $direccionInsc !== '' ? $direccionInsc : null,
-                ':ciudad' => $ciudadInsc !== '' ? $ciudadInsc : null,
-                ':provincia' => $provinciaInsc !== '' ? $provinciaInsc : null,
-                ':pais' => $paisInsc,
-                ':id' => (int)$certificacionRow['id_certificacion'],
-            ]);
+             WHERE id_certificacion = :id
+        ');
+        $upCert->execute([
+            ':precio' => $precioFinal,
+            ':moneda' => $monedaPrecio,
+            ':obs' => $observacionesCert,
+            ':nombre' => $nombreInscrito,
+            ':apellido' => $apellidoInscrito,
+            ':email' => $emailInscrito,
+            ':telefono' => $telefonoInscrito,
+            ':id' => (int)$certificacionRow['id_certificacion'],
+        ]);
             registrar_historico_certificacion($con, (int)$certificacionRow['id_certificacion'], 3);
         }
 

--- a/checkout/gracias.php
+++ b/checkout/gracias.php
@@ -90,10 +90,10 @@ LEFT JOIN checkout_certificaciones cert ON p.id_certificacion = cert.id_certific
 LEFT JOIN cursos cur_cap ON cap.id_curso = cur_cap.id_curso
 LEFT JOIN cursos cur_cert ON cert.id_curso = cur_cert.id_curso
 WHERE (
-        (p.id_capacitacion IS NOT NULL AND p.id_capacitacion = :id_cap)
-        OR (p.id_certificacion IS NOT NULL AND p.id_certificacion = :id_cert)
-        OR (cap.id_capacitacion IS NOT NULL AND cap.id_capacitacion = :id_cap)
-        OR (cert.id_certificacion IS NOT NULL AND cert.id_certificacion = :id_cert)
+        (p.id_capacitacion IS NOT NULL AND p.id_capacitacion = :id_cap_pago)
+        OR (p.id_certificacion IS NOT NULL AND p.id_certificacion = :id_cert_pago)
+        OR (cap.id_capacitacion IS NOT NULL AND cap.id_capacitacion = :id_cap_registro)
+        OR (cert.id_certificacion IS NOT NULL AND cert.id_certificacion = :id_cert_registro)
     )
 ORDER BY p.id_pago DESC
 LIMIT 1
@@ -101,8 +101,10 @@ SQL;
 
         $st = $con->prepare($sqlDetalle);
         $st->execute([
-            ':id_cap' => $manualOrderId,
-            ':id_cert' => $manualOrderId,
+            ':id_cap_pago' => $manualOrderId,
+            ':id_cert_pago' => $manualOrderId,
+            ':id_cap_registro' => $manualOrderId,
+            ':id_cert_registro' => $manualOrderId,
         ]);
         $row = $st->fetch(PDO::FETCH_ASSOC);
         if (!$row) {

--- a/checkout/gracias.php
+++ b/checkout/gracias.php
@@ -89,13 +89,21 @@ LEFT JOIN checkout_capacitaciones cap ON p.id_capacitacion = cap.id_capacitacion
 LEFT JOIN checkout_certificaciones cert ON p.id_certificacion = cert.id_certificacion
 LEFT JOIN cursos cur_cap ON cap.id_curso = cur_cap.id_curso
 LEFT JOIN cursos cur_cert ON cert.id_curso = cur_cert.id_curso
-WHERE (p.id_capacitacion = :id OR p.id_certificacion = :id OR cap.id_capacitacion = :id OR cert.id_certificacion = :id)
+WHERE (
+        (p.id_capacitacion IS NOT NULL AND p.id_capacitacion = :id_cap)
+        OR (p.id_certificacion IS NOT NULL AND p.id_certificacion = :id_cert)
+        OR (cap.id_capacitacion IS NOT NULL AND cap.id_capacitacion = :id_cap)
+        OR (cert.id_certificacion IS NOT NULL AND cert.id_certificacion = :id_cert)
+    )
 ORDER BY p.id_pago DESC
 LIMIT 1
 SQL;
 
         $st = $con->prepare($sqlDetalle);
-        $st->execute([':id' => $manualOrderId]);
+        $st->execute([
+            ':id_cap' => $manualOrderId,
+            ':id_cert' => $manualOrderId,
+        ]);
         $row = $st->fetch(PDO::FETCH_ASSOC);
         if (!$row) {
             throw new RuntimeException('No encontramos la inscripción generada.');

--- a/checkout/gracias.php
+++ b/checkout/gracias.php
@@ -83,7 +83,7 @@ SELECT
     COALESCE(cap.telefono, cert.telefono) AS telefono,
     COALESCE(cap.precio_total, cert.precio_total, p.monto) AS precio_total,
     COALESCE(cap.moneda, cert.moneda, p.moneda) AS moneda_registro,
-    COALESCE(cur_cap.nombre_curso, cur_cert.nombre_certificacion, cur_cert.nombre_curso, '') AS nombre_curso
+    COALESCE(cur_cap.nombre_curso, cur_cert.nombre_curso, '') AS nombre_curso
 FROM checkout_pagos p
 LEFT JOIN checkout_capacitaciones cap ON p.id_capacitacion = cap.id_capacitacion
 LEFT JOIN checkout_certificaciones cert ON p.id_certificacion = cert.id_certificacion

--- a/checkout/gracias_certificacion.php
+++ b/checkout/gracias_certificacion.php
@@ -33,7 +33,7 @@ if (!$data && $certificacionId > 0) {
 
         $st = $con->prepare('
             SELECT cc.id_certificacion, cc.id_curso, cc.nombre, cc.apellido, cc.email, cc.telefono,
-                   cc.precio_total, cc.moneda, cc.id_estado, c.nombre_curso, c.nombre_certificacion
+                   cc.precio_total, cc.moneda, cc.id_estado, c.nombre_curso
               FROM checkout_certificaciones cc
          LEFT JOIN cursos c ON c.id_curso = cc.id_curso
              WHERE cc.id_certificacion = :id

--- a/checkout/mercadopago_common.php
+++ b/checkout/mercadopago_common.php
@@ -136,13 +136,27 @@ if (!function_exists('checkout_get_base_url')) {
     {
         $configured = checkout_env('APP_BASE_URL') ?? checkout_env('BASE_URL');
         if ($configured) {
-            return rtrim($configured, '/');
+            $configured = trim($configured);
+            if ($configured !== '') {
+                if (!preg_match('#^https?://#i', $configured)) {
+                    $configured = 'https://' . ltrim($configured, '/');
+                }
+                return rtrim($configured, '/');
+            }
         }
+
         $https = (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
             || ((string) ($_SERVER['SERVER_PORT'] ?? '') === '443');
         $scheme = $https ? 'https' : 'http';
         $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-        return $scheme . '://' . $host;
+        if ($host === '') {
+            $host = 'localhost';
+        }
+        if (!preg_match('#^https?://#i', $host)) {
+            $host = ltrim($host, '/');
+            $host = $scheme . '://' . $host;
+        }
+        return rtrim($host, '/');
     }
 }
 

--- a/checkout/mercadopago_common.php
+++ b/checkout/mercadopago_common.php
@@ -145,17 +145,28 @@ if (!function_exists('checkout_get_base_url')) {
             }
         }
 
+        $forwardedProto = strtolower((string) ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? ''));
+        $forwardedSsl = strtolower((string) ($_SERVER['HTTP_X_FORWARDED_SSL'] ?? ''));
         $https = (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
-            || ((string) ($_SERVER['SERVER_PORT'] ?? '') === '443');
+            || ((string) ($_SERVER['SERVER_PORT'] ?? '') === '443')
+            || $forwardedProto === 'https'
+            || $forwardedSsl === 'on';
         $scheme = $https ? 'https' : 'http';
-        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+
+        $host = $_SERVER['HTTP_HOST']
+            ?? $_SERVER['HTTP_X_FORWARDED_HOST']
+            ?? $_SERVER['SERVER_NAME']
+            ?? 'localhost';
+
+        $host = trim((string) $host);
         if ($host === '') {
             $host = 'localhost';
         }
+
         if (!preg_match('#^https?://#i', $host)) {
-            $host = ltrim($host, '/');
-            $host = $scheme . '://' . $host;
+            $host = $scheme . '://' . ltrim($host, '/');
         }
+
         return rtrim($host, '/');
     }
 }

--- a/checkout/mercadopago_init.php
+++ b/checkout/mercadopago_init.php
@@ -244,11 +244,6 @@ try {
                    apellido = :apellido,
                    email = :email,
                    telefono = :telefono,
-                   dni = :dni,
-                   direccion = :direccion,
-                   ciudad = :ciudad,
-                   provincia = :provincia,
-                   pais = :pais,
                    acepta_tyc = 1
              WHERE id_certificacion = :id
         ');
@@ -260,11 +255,6 @@ try {
             ':apellido' => $apellido,
             ':email' => $email,
             ':telefono' => $telefono,
-            ':dni' => $dni !== '' ? $dni : null,
-            ':direccion' => $direccion !== '' ? $direccion : null,
-            ':ciudad' => $ciudad !== '' ? $ciudad : null,
-            ':provincia' => $provincia !== '' ? $provincia : null,
-            ':pais' => $pais !== '' ? $pais : 'Argentina',
             ':id' => (int)$certificacionRow['id_certificacion'],
         ]);
         $registrarHistoricoCert($con, (int)$certificacionRow['id_certificacion'], 3);

--- a/checkout/mercadopago_service.php
+++ b/checkout/mercadopago_service.php
@@ -355,6 +355,8 @@ function checkout_sync_mp_payment(PDO $con, array $mpRow, ?array $paymentData, s
     checkout_log_event('checkout_mp_sync', [
         'id_pago' => $mpRow['id_pago'],
         'mp_status' => $mpStatus,
+        'status_detail' => $statusDetail,
+        'payment_type' => $paymentType,
         'estado_pago' => $estadoPago,
         'source' => $source,
         'emails_sent' => $emailsSent,

--- a/checkout/mercadopago_service.php
+++ b/checkout/mercadopago_service.php
@@ -27,7 +27,7 @@ function checkout_fetch_mp_order(PDO $con, array $lookup): ?array
                        CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.provincia ELSE NULL END AS provincia,
                        CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.pais ELSE NULL END AS pais,
                        COALESCE(cap.id_curso, cert.id_curso) AS id_curso,
-                       COALESCE(cur_cap.nombre_curso, cur_cert.nombre_certificacion, cur_cert.nombre_curso, '') AS nombre_curso
+                       COALESCE(cur_cap.nombre_curso, cur_cert.nombre_curso, '') AS nombre_curso
                   FROM checkout_mercadopago mp
             INNER JOIN checkout_pagos p ON mp.id_pago = p.id_pago
              LEFT JOIN checkout_capacitaciones cap ON p.id_capacitacion = cap.id_capacitacion

--- a/checkout/mercadopago_service.php
+++ b/checkout/mercadopago_service.php
@@ -9,13 +9,31 @@ require_once __DIR__ . '/mercadopago_mailer.php';
  */
 function checkout_fetch_mp_order(PDO $con, array $lookup): ?array
 {
-    $baseSql = "SELECT mp.*, p.estado AS pago_estado, p.monto, p.moneda, p.id_inscripcion,
-                       i.nombre, i.apellido, i.email, i.telefono, i.dni, i.direccion, i.ciudad, i.provincia, i.pais,
-                       c.nombre_curso
+    $baseSql = "SELECT mp.*, p.estado AS pago_estado, p.monto, p.moneda,
+                       p.id_capacitacion, p.id_certificacion,
+                       COALESCE(cap.id_capacitacion, cert.id_certificacion) AS id_inscripcion,
+                       CASE
+                           WHEN p.id_capacitacion IS NOT NULL THEN 'capacitacion'
+                           WHEN p.id_certificacion IS NOT NULL THEN 'certificacion'
+                           ELSE NULL
+                       END AS tipo_checkout,
+                       COALESCE(cap.nombre, cert.nombre) AS nombre,
+                       COALESCE(cap.apellido, cert.apellido) AS apellido,
+                       COALESCE(cap.email, cert.email) AS email,
+                       COALESCE(cap.telefono, cert.telefono) AS telefono,
+                       CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.dni ELSE NULL END AS dni,
+                       CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.direccion ELSE NULL END AS direccion,
+                       CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.ciudad ELSE NULL END AS ciudad,
+                       CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.provincia ELSE NULL END AS provincia,
+                       CASE WHEN p.id_capacitacion IS NOT NULL THEN cap.pais ELSE NULL END AS pais,
+                       COALESCE(cap.id_curso, cert.id_curso) AS id_curso,
+                       COALESCE(cur_cap.nombre_curso, cur_cert.nombre_certificacion, cur_cert.nombre_curso, '') AS nombre_curso
                   FROM checkout_mercadopago mp
             INNER JOIN checkout_pagos p ON mp.id_pago = p.id_pago
-            INNER JOIN checkout_inscripciones i ON p.id_inscripcion = i.id_inscripcion
-            INNER JOIN cursos c ON i.id_curso = c.id_curso
+             LEFT JOIN checkout_capacitaciones cap ON p.id_capacitacion = cap.id_capacitacion
+             LEFT JOIN checkout_certificaciones cert ON p.id_certificacion = cert.id_certificacion
+             LEFT JOIN cursos cur_cap ON cap.id_curso = cur_cap.id_curso
+             LEFT JOIN cursos cur_cert ON cert.id_curso = cur_cert.id_curso
                  WHERE %s
               ORDER BY mp.id_mp DESC
                  LIMIT 1";
@@ -190,6 +208,13 @@ function checkout_sync_mp_payment(PDO $con, array $mpRow, ?array $paymentData, s
     $estadoPago = checkout_map_mp_status_to_estado($mpStatus);
 
     $payloadData = checkout_decode_payload($mpRow['payload'] ?? null);
+    if (!empty($payloadData['request']['metadata']['tipo_checkout']) && empty($mpRow['tipo_checkout'])) {
+        $tipoFromPayload = (string) $payloadData['request']['metadata']['tipo_checkout'];
+        $tipoFromPayload = strtolower(trim($tipoFromPayload));
+        if ($tipoFromPayload !== '') {
+            $mpRow['tipo_checkout'] = $tipoFromPayload;
+        }
+    }
     $payloadData['history'] = $payloadData['history'] ?? [];
     $payloadData['history'][] = [
         'source' => $source,
@@ -299,6 +324,7 @@ function checkout_sync_mp_payment(PDO $con, array $mpRow, ?array $paymentData, s
         if (!$alreadySent) {
             $orderData = [
                 'orden' => $mpRow['id_inscripcion'],
+                'tipo_checkout' => $mpRow['tipo_checkout'] ?? null,
                 'curso' => $mpRow['nombre_curso'],
                 'nombre' => $mpRow['nombre'],
                 'apellido' => $mpRow['apellido'],


### PR DESCRIPTION
## Resumen
- adaptar la lectura de órdenes de Mercado Pago para usar `checkout_capacitaciones` y `checkout_certificaciones`, manteniendo el tipo de checkout disponible
- registrar nuevas inscripciones en `checkout_capacitaciones` o vincular certificaciones existentes al generar preferencias de Mercado Pago, guardando la referencia correspondiente en los metadatos
- actualizar la pantalla de agradecimiento para consultar la nueva estructura de pagos y ajustar el tipo de checkout mostrado

## Pruebas
- php -l checkout/mercadopago_service.php
- php -l checkout/mercadopago_init.php
- php -l checkout/gracias.php


------
https://chatgpt.com/codex/tasks/task_e_68dca25b72b08322aff2c2d863832b0e