### PR TITLE
Fix certification payment state handling

### DIFF
--- a/admin/aside.php
+++ b/admin/aside.php
@@ -101,6 +101,13 @@
               </a>
             </li>
 
+            <li class="nav-item">
+              <a href="pagos.php" class="nav-link">
+                <i class="fas fa-solid fa-receipt"></i>
+                <p>Pagos</p>
+              </a>
+            </li>
+
           </ul>
         </nav>
         <!-- /.sidebar-menu -->

--- a/admin/pagos.php
+++ b/admin/pagos.php
@@ -1,0 +1,282 @@
+<?php
+require_once '../sbd.php';
+include '../admin/header.php';
+include '../admin/aside.php';
+include '../admin/footer.php';
+
+$pagosStmt = $con->prepare(
+    "SELECT p.*,\n"
+    . "       CASE\n"
+    . "           WHEN p.id_capacitacion IS NOT NULL THEN 'capacitacion'\n"
+    . "           WHEN p.id_certificacion IS NOT NULL THEN 'certificacion'\n"
+    . "           ELSE 'curso'\n"
+    . "       END AS tipo_checkout,\n"
+    . "       COALESCE(cap.nombre, cert.nombre) AS alumno_nombre,\n"
+    . "       COALESCE(cap.apellido, cert.apellido) AS alumno_apellido,\n"
+    . "       COALESCE(cap.email, cert.email) AS alumno_email,\n"
+    . "       COALESCE(cap.telefono, cert.telefono) AS alumno_telefono,\n"
+    . "       COALESCE(cur_cap.nombre_curso, cur_cert.nombre_curso, '') AS curso_nombre\n"
+    . "  FROM checkout_pagos p\n"
+    . "  LEFT JOIN checkout_capacitaciones cap ON p.id_capacitacion = cap.id_capacitacion\n"
+    . "  LEFT JOIN checkout_certificaciones cert ON p.id_certificacion = cert.id_certificacion\n"
+    . "  LEFT JOIN cursos cur_cap ON cap.id_curso = cur_cap.id_curso\n"
+    . "  LEFT JOIN cursos cur_cert ON cert.id_curso = cur_cert.id_curso\n"
+    . " WHERE p.metodo = 'transferencia'\n"
+    . " ORDER BY (p.estado = 'pendiente') DESC, p.creado_en DESC"
+);
+$pagosStmt->execute();
+$pagos = $pagosStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$successMessage = $_SESSION['pagos_admin_success'] ?? null;
+$warningMessage = $_SESSION['pagos_admin_warning'] ?? null;
+$errorMessage = $_SESSION['pagos_admin_error'] ?? null;
+unset($_SESSION['pagos_admin_success'], $_SESSION['pagos_admin_warning'], $_SESSION['pagos_admin_error']);
+
+function h(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
+
+function pago_estado_badge(string $estado): string
+{
+    $estado = strtolower($estado);
+    return match ($estado) {
+        'pagado' => '<span class="badge bg-success">Aprobado</span>',
+        'rechazado' => '<span class="badge bg-danger">Rechazado</span>',
+        'cancelado' => '<span class="badge bg-secondary">Cancelado</span>',
+        default => '<span class="badge bg-warning text-dark">Pendiente</span>',
+    };
+}
+
+function pago_tipo_label(string $tipo): string
+{
+    return $tipo === 'certificacion'
+        ? 'Certificación'
+        : ($tipo === 'capacitacion' ? 'Capacitación' : 'Curso');
+}
+
+function pago_format_currency(?float $amount, ?string $currency): string
+{
+    $amount = $amount ?? 0.0;
+    $currency = strtoupper(trim((string)$currency));
+    $symbol = '$';
+    if ($currency === 'USD') {
+        $symbol = 'US$';
+    } elseif ($currency === 'EUR') {
+        $symbol = '€';
+    }
+    return sprintf('%s %s', $symbol, number_format($amount, 2, ',', '.'));
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pagos por transferencia | Panel Administrativo</title>
+</head>
+
+<body class="hold-transition sidebar-mini layout-fixed">
+    <div class="wrapper">
+        <div class="content-wrapper">
+            <section class="content">
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="card">
+                                <div class="card-header d-flex justify-content-between align-items-center">
+                                    <h3 class="card-title">Pagos por transferencia</h3>
+                                </div>
+                                <div class="card-body">
+                                    <?php if ($successMessage): ?>
+                                        <div class="alert alert-success alert-dismissible fade show" role="alert">
+                                            <i class="fas fa-circle-check me-2"></i><?php echo h($successMessage); ?>
+                                            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($warningMessage): ?>
+                                        <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                                            <i class="fas fa-triangle-exclamation me-2"></i><?php echo h($warningMessage); ?>
+                                            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ($errorMessage): ?>
+                                        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                                            <i class="fas fa-circle-xmark me-2"></i><?php echo h($errorMessage); ?>
+                                            <button type="button" class="close" data-dismiss="alert" aria-label="Cerrar">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                    <?php endif; ?>
+
+                                    <div class="table-responsive">
+                                        <table id="tablaPagos" class="table table-bordered table-striped align-middle">
+                                            <thead>
+                                                <tr>
+                                                    <th style="width: 70px">#</th>
+                                                    <th>Fecha</th>
+                                                    <th>Tipo</th>
+                                                    <th>Curso</th>
+                                                    <th>Alumno</th>
+                                                    <th>Monto</th>
+                                                    <th>Estado</th>
+                                                    <th>Observaciones</th>
+                                                    <th>Comprobante</th>
+                                                    <th style="width: 180px">Acciones</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <?php foreach ($pagos as $pago): ?>
+                                                    <?php
+                                                    $pagoId = (int)$pago['id_pago'];
+                                                    $fecha = '';
+                                                    if (!empty($pago['creado_en'])) {
+                                                        $timestamp = strtotime((string)$pago['creado_en']);
+                                                        if ($timestamp) {
+                                                            $fecha = date('d/m/Y H:i', $timestamp);
+                                                        }
+                                                    }
+                                                    $alumno = trim((string)($pago['alumno_nombre'] ?? ''));
+                                                    $apellido = trim((string)($pago['alumno_apellido'] ?? ''));
+                                                    if ($apellido !== '') {
+                                                        $alumno = $alumno !== '' ? $alumno . ' ' . $apellido : $apellido;
+                                                    }
+                                                    if ($alumno === '') {
+                                                        $alumno = $pago['alumno_email'] ?? '—';
+                                                    }
+                                                    $estado = strtolower((string)($pago['estado'] ?? 'pendiente'));
+                                                    $comprobantePath = trim((string)($pago['comprobante_path'] ?? ''));
+                                                    $comprobanteLabel = trim((string)($pago['comprobante_nombre'] ?? 'Ver archivo'));
+                                                    $tipo = (string)($pago['tipo_checkout'] ?? 'curso');
+                                                    $puedeGestionar = ($estado === 'pendiente');
+                                                    $observaciones = trim((string)($pago['observaciones'] ?? ''));
+                                                    $observacionesResumen = $observaciones;
+                                                    if ($observaciones !== '') {
+                                                        if (function_exists('mb_strlen')) {
+                                                            $observacionesResumen = mb_strlen($observaciones, 'UTF-8') > 60
+                                                                ? mb_substr($observaciones, 0, 60, 'UTF-8') . '…'
+                                                                : $observaciones;
+                                                        } elseif (strlen($observaciones) > 60) {
+                                                            $observacionesResumen = substr($observaciones, 0, 60) . '…';
+                                                        }
+                                                    }
+                                                    ?>
+                                                    <tr>
+                                                        <td><strong>#<?php echo h(str_pad((string)$pagoId, 5, '0', STR_PAD_LEFT)); ?></strong></td>
+                                                        <td><?php echo h($fecha); ?></td>
+                                                        <td><?php echo h(pago_tipo_label($tipo)); ?></td>
+                                                        <td><?php echo h($pago['curso_nombre'] ?? ''); ?></td>
+                                                        <td>
+                                                            <div class="fw-semibold"><?php echo h($alumno); ?></div>
+                                                            <?php if (!empty($pago['alumno_email'])): ?>
+                                                                <div class="small text-muted"><a href="mailto:<?php echo h($pago['alumno_email']); ?>"><?php echo h($pago['alumno_email']); ?></a></div>
+                                                            <?php endif; ?>
+                                                            <?php if (!empty($pago['alumno_telefono'])): ?>
+                                                                <div class="small text-muted"><?php echo h($pago['alumno_telefono']); ?></div>
+                                                            <?php endif; ?>
+                                                        </td>
+                                                        <td><?php echo h(pago_format_currency(isset($pago['monto']) ? (float)$pago['monto'] : 0.0, $pago['moneda'] ?? 'ARS')); ?></td>
+                                                        <td><?php echo pago_estado_badge($estado); ?></td>
+                                                        <td>
+                                                            <?php if ($observaciones !== ''): ?>
+                                                                <span title="<?php echo h($observaciones); ?>"><?php echo h($observacionesResumen); ?></span>
+                                                            <?php else: ?>
+                                                                <span class="text-muted">—</span>
+                                                            <?php endif; ?>
+                                                        </td>
+                                                        <td>
+                                                            <?php if ($comprobantePath !== ''): ?>
+                                                                <a class="btn btn-outline-primary btn-sm" href="../<?php echo h(ltrim($comprobantePath, '/')); ?>" target="_blank" rel="noopener">
+                                                                    <i class="fas fa-file-arrow-down me-1"></i><?php echo h($comprobanteLabel); ?>
+                                                                </a>
+                                                            <?php else: ?>
+                                                                <span class="text-muted">Sin archivo</span>
+                                                            <?php endif; ?>
+                                                        </td>
+                                                        <td>
+                                                            <div class="d-flex flex-column gap-2">
+                                                                <?php if ($puedeGestionar): ?>
+                                                                    <button type="button" class="btn btn-success btn-sm btn-aprobar-pago" data-id="<?php echo $pagoId; ?>">
+                                                                        <i class="fas fa-check me-1"></i>Aprobar
+                                                                    </button>
+                                                                    <button type="button" class="btn btn-danger btn-sm btn-rechazar-pago" data-id="<?php echo $pagoId; ?>">
+                                                                        <i class="fas fa-times me-1"></i>Rechazar
+                                                                    </button>
+                                                                <?php else: ?>
+                                                                    <span class="text-muted small">Sin acciones</span>
+                                                                <?php endif; ?>
+                                                            </div>
+                                                            <form id="formPago<?php echo $pagoId; ?>" action="procesarsbd.php" method="POST" class="d-none">
+                                                                <input type="hidden" name="__accion" value="">
+                                                                <input type="hidden" name="id_pago" value="<?php echo $pagoId; ?>">
+                                                            </form>
+                                                        </td>
+                                                    </tr>
+                                                <?php endforeach; ?>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const table = $("#tablaPagos").DataTable({
+                responsive: true,
+                lengthChange: true,
+                autoWidth: false,
+                order: [[0, 'desc']],
+                language: {
+                    url: "//cdn.datatables.net/plug-ins/1.13.7/i18n/es-ES.json"
+                },
+                buttons: ["copy", "csv", "excel", "pdf", "print", "colvis"]
+            });
+            table.buttons().container().appendTo('#tablaPagos_wrapper .col-md-6:eq(0)');
+
+            const confirmar = (mensaje) => window.confirm(mensaje);
+
+            document.querySelectorAll('.btn-aprobar-pago').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    if (!confirmar('¿Confirmás la aprobación de este pago?')) {
+                        return;
+                    }
+                    const id = btn.dataset.id;
+                    const form = document.getElementById('formPago' + id);
+                    if (!form) {
+                        return;
+                    }
+                    form.querySelector('input[name="__accion"]').value = 'aprobar_pago_transferencia';
+                    form.submit();
+                });
+            });
+
+            document.querySelectorAll('.btn-rechazar-pago').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    if (!confirmar('¿Confirmás el rechazo de este pago?')) {
+                        return;
+                    }
+                    const id = btn.dataset.id;
+                    const form = document.getElementById('formPago' + id);
+                    if (!form) {
+                        return;
+                    }
+                    form.querySelector('input[name="__accion"]').value = 'rechazar_pago_transferencia';
+                    form.submit();
+                });
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/admin/procesarsbd.php
+++ b/admin/procesarsbd.php
@@ -76,6 +76,18 @@ function registrar_historico_certificacion(PDO $con, int $idCertificacion, int $
     ]);
 }
 
+function registrar_historico_capacitacion(PDO $con, int $idCapacitacion, int $estado): void
+{
+    $hist = $con->prepare('
+        INSERT INTO historico_estado_capacitaciones (id_capacitacion, id_estado)
+        VALUES (:id, :estado)
+    ');
+    $hist->execute([
+        ':id' => $idCapacitacion,
+        ':estado' => $estado,
+    ]);
+}
+
 function obtener_usuario_id_de_sesion(): int
 {
     if (isset($_SESSION['id_usuario']) && is_numeric($_SESSION['id_usuario'])) {
@@ -129,6 +141,8 @@ try {
     $isCrearCertificacion = ($accion === 'crear_certificacion');
     $isAprobarCertificacion = ($accion === 'aprobar_certificacion');
     $isRechazarCertificacion = ($accion === 'rechazar_certificacion');
+    $isAprobarPagoTransferencia = ($accion === 'aprobar_pago_transferencia');
+    $isRechazarPagoTransferencia = ($accion === 'rechazar_pago_transferencia');
 
     $checkoutIsCrearOrden = isset($_POST['crear_orden']) || ($accion === 'crear_orden');
 
@@ -691,10 +705,15 @@ try {
             if ($observacionesExistentes !== '') {
                 $observacionesCert .= ' | ' . $observacionesExistentes;
             }
+
+            $nombreActualizar = $nombreInscrito !== '' ? $nombreInscrito : (string)($certificacionRow['nombre'] ?? '');
+            $apellidoActualizar = $apellidoInscrito !== '' ? $apellidoInscrito : (string)($certificacionRow['apellido'] ?? '');
+            $emailActualizar = $emailInscrito !== '' ? $emailInscrito : (string)($certificacionRow['email'] ?? '');
+            $telefonoActualizar = $telefonoInscrito !== '' ? $telefonoInscrito : (string)($certificacionRow['telefono'] ?? '');
+
             $upCert = $con->prepare('
                 UPDATE checkout_certificaciones
-                   SET id_estado = 3,
-                       precio_total = :precio,
+                   SET precio_total = :precio,
                        moneda = :moneda,
                        observaciones = :obs,
                        nombre = :nombre,
@@ -703,18 +722,17 @@ try {
                        telefono = :telefono,
                        acepta_tyc = 1
              WHERE id_certificacion = :id
-        ');
-        $upCert->execute([
-            ':precio' => $precioFinal,
-            ':moneda' => $monedaPrecio,
-            ':obs' => $observacionesCert,
-            ':nombre' => $nombreInscrito,
-            ':apellido' => $apellidoInscrito,
-            ':email' => $emailInscrito,
-            ':telefono' => $telefonoInscrito,
-            ':id' => (int)$certificacionRow['id_certificacion'],
-        ]);
-            registrar_historico_certificacion($con, (int)$certificacionRow['id_certificacion'], 3);
+            ');
+            $upCert->execute([
+                ':precio' => $precioFinal,
+                ':moneda' => strtoupper($monedaPrecio),
+                ':obs' => $observacionesCert,
+                ':nombre' => $nombreActualizar,
+                ':apellido' => $apellidoActualizar,
+                ':email' => $emailActualizar,
+                ':telefono' => $telefonoActualizar,
+                ':id' => (int)$certificacionRow['id_certificacion'],
+            ]);
         }
 
         if ($registroId <= 0) {
@@ -755,6 +773,209 @@ try {
         $redirectUrl = '../checkout/gracias.php?' . http_build_query($redirectQuery);
 
         header('Location: ' . $redirectUrl);
+        exit;
+    }
+
+    if ($isAprobarPagoTransferencia || $isRechazarPagoTransferencia) {
+        $pagoId = (int)($_POST['id_pago'] ?? 0);
+        if ($pagoId <= 0) {
+            throw new InvalidArgumentException('Pago inválido.');
+        }
+
+        $pagoStmt = $con->prepare(
+            "SELECT p.*,\n"
+            . "       CASE\n"
+            . "           WHEN p.id_capacitacion IS NOT NULL THEN 'capacitacion'\n"
+            . "           WHEN p.id_certificacion IS NOT NULL THEN 'certificacion'\n"
+            . "           ELSE 'curso'\n"
+            . "       END AS tipo_checkout,\n"
+            . "       cap.id_estado   AS cap_estado,\n"
+            . "       cap.creado_por  AS cap_creado_por,\n"
+            . "       cap.nombre      AS cap_nombre,\n"
+            . "       cap.apellido    AS cap_apellido,\n"
+            . "       cap.email       AS cap_email,\n"
+            . "       cap.telefono    AS cap_telefono,\n"
+            . "       cap.id_curso    AS cap_curso_id,\n"
+            . "       cert.id_estado  AS cert_estado,\n"
+            . "       cert.creado_por AS cert_creado_por,\n"
+            . "       cert.nombre     AS cert_nombre,\n"
+            . "       cert.apellido   AS cert_apellido,\n"
+            . "       cert.email      AS cert_email,\n"
+            . "       cert.telefono   AS cert_telefono,\n"
+            . "       cert.id_curso   AS cert_curso_id,\n"
+            . "       cert.observaciones AS cert_observaciones,\n"
+            . "       COALESCE(cap.nombre, cert.nombre)   AS alumno_nombre,\n"
+            . "       COALESCE(cap.apellido, cert.apellido) AS alumno_apellido,\n"
+            . "       COALESCE(cap.email, cert.email)     AS alumno_email,\n"
+            . "       COALESCE(cap.telefono, cert.telefono) AS alumno_telefono,\n"
+            . "       COALESCE(cur_cap.nombre_curso, cur_cert.nombre_curso, '') AS curso_nombre\n"
+            . "  FROM checkout_pagos p\n"
+            . "  LEFT JOIN checkout_capacitaciones cap ON p.id_capacitacion = cap.id_capacitacion\n"
+            . "  LEFT JOIN checkout_certificaciones cert ON p.id_certificacion = cert.id_certificacion\n"
+            . "  LEFT JOIN cursos cur_cap ON cap.id_curso = cur_cap.id_curso\n"
+            . "  LEFT JOIN cursos cur_cert ON cert.id_curso = cur_cert.id_curso\n"
+            . " WHERE p.id_pago = :id\n"
+            . " LIMIT 1"
+        );
+        $pagoStmt->execute([':id' => $pagoId]);
+        $pagoRow = $pagoStmt->fetch(PDO::FETCH_ASSOC);
+        if (!$pagoRow) {
+            throw new RuntimeException('No encontramos el pago seleccionado.');
+        }
+
+        $metodoPago = strtolower((string)($pagoRow['metodo'] ?? ''));
+        if ($metodoPago !== 'transferencia') {
+            throw new RuntimeException('Sólo se pueden gestionar pagos realizados por transferencia.');
+        }
+
+        $estadoPagoActual = strtolower((string)($pagoRow['estado'] ?? 'pendiente'));
+        $nuevoEstadoPago = $isAprobarPagoTransferencia ? 'pagado' : 'rechazado';
+
+        if ($estadoPagoActual === $nuevoEstadoPago) {
+            $_SESSION['pagos_admin_success'] = $isAprobarPagoTransferencia
+                ? 'El pago ya se encontraba aprobado.'
+                : 'El pago ya se encontraba marcado como rechazado.';
+            header('Location: pagos.php');
+            exit;
+        }
+
+        $ahoraLabel = (new DateTimeImmutable('now'))->format('d/m/Y H:i');
+        $notaPago = $isAprobarPagoTransferencia
+            ? 'Pago aprobado manualmente el ' . $ahoraLabel
+            : 'Pago rechazado manualmente el ' . $ahoraLabel;
+        $obsPagoActual = trim((string)($pagoRow['observaciones'] ?? ''));
+        $observacionesPago = $notaPago;
+        if ($obsPagoActual !== '') {
+            $observacionesPago .= ' | ' . $obsPagoActual;
+        }
+
+        $capacitacionId = isset($pagoRow['id_capacitacion']) ? (int)$pagoRow['id_capacitacion'] : 0;
+        $certificacionId = isset($pagoRow['id_certificacion']) ? (int)$pagoRow['id_certificacion'] : 0;
+
+        $con->beginTransaction();
+
+        $upPago = $con->prepare('UPDATE checkout_pagos SET estado = :estado, observaciones = :obs WHERE id_pago = :id');
+        $upPago->execute([
+            ':estado' => $nuevoEstadoPago,
+            ':obs' => $observacionesPago,
+            ':id' => $pagoId,
+        ]);
+
+        $tipoCheckout = (string)($pagoRow['tipo_checkout'] ?? '');
+
+        if ($capacitacionId > 0) {
+            $estadoCapActual = isset($pagoRow['cap_estado']) ? (int)$pagoRow['cap_estado'] : 0;
+            $estadoCapNuevo = $estadoCapActual;
+            if ($isAprobarPagoTransferencia) {
+                $estadoCapNuevo = 3;
+            } elseif ($isRechazarPagoTransferencia) {
+                $estadoCapNuevo = 4;
+            }
+
+            if ($estadoCapNuevo !== $estadoCapActual && $estadoCapNuevo > 0) {
+                $upCap = $con->prepare('UPDATE checkout_capacitaciones SET id_estado = :estado WHERE id_capacitacion = :id');
+                $upCap->execute([
+                    ':estado' => $estadoCapNuevo,
+                    ':id' => $capacitacionId,
+                ]);
+                registrar_historico_capacitacion($con, $capacitacionId, $estadoCapNuevo);
+            }
+        }
+
+        if ($certificacionId > 0) {
+            $estadoCertActual = isset($pagoRow['cert_estado']) ? (int)$pagoRow['cert_estado'] : 0;
+            $estadoCertNuevo = $estadoCertActual;
+            if ($isAprobarPagoTransferencia) {
+                $estadoCertNuevo = 3;
+            } elseif ($isRechazarPagoTransferencia) {
+                $estadoCertNuevo = 2;
+            }
+
+            $obsCertActual = trim((string)($pagoRow['cert_observaciones'] ?? ''));
+            $notaCert = $notaPago;
+            if ($obsCertActual !== '') {
+                $notaCert .= ' | ' . $obsCertActual;
+            }
+
+            if ($estadoCertNuevo !== $estadoCertActual) {
+                $sqlCert = 'UPDATE checkout_certificaciones SET observaciones = :obs, id_estado = :estado WHERE id_certificacion = :id';
+                $paramsCert = [
+                    ':obs' => $notaCert,
+                    ':estado' => $estadoCertNuevo,
+                    ':id' => $certificacionId,
+                ];
+                $con->prepare($sqlCert)->execute($paramsCert);
+                registrar_historico_certificacion($con, $certificacionId, $estadoCertNuevo);
+            } else {
+                $sqlCert = 'UPDATE checkout_certificaciones SET observaciones = :obs WHERE id_certificacion = :id';
+                $con->prepare($sqlCert)->execute([
+                    ':obs' => $notaCert,
+                    ':id' => $certificacionId,
+                ]);
+            }
+        }
+
+        $con->commit();
+
+        $emailError = null;
+        if ($isAprobarPagoTransferencia && $tipoCheckout === 'capacitacion') {
+            $destinatario = trim((string)($pagoRow['alumno_email'] ?? ''));
+            if ($destinatario !== '') {
+                try {
+                    require_once __DIR__ . '/../checkout/mercadopago_mailer.php';
+                    $studentName = trim(((string)($pagoRow['alumno_nombre'] ?? '')) . ' ' . ((string)($pagoRow['alumno_apellido'] ?? '')));
+                    if ($studentName === '') {
+                        $studentName = $destinatario;
+                    }
+                    $cursoNombre = trim((string)($pagoRow['curso_nombre'] ?? 'tu capacitación'));
+                    $monto = isset($pagoRow['monto']) ? (float)$pagoRow['monto'] : 0.0;
+                    $moneda = (string)($pagoRow['moneda'] ?? 'ARS');
+                    $montoLabel = checkout_format_currency($monto, $moneda);
+
+                    $mail = checkout_create_mailer();
+                    $mail->addAddress($destinatario, $studentName);
+                    $mail->Subject = 'Confirmación de pago por transferencia - ' . $cursoNombre;
+
+                    $body = '<p>Hola ' . htmlspecialchars($studentName, ENT_QUOTES, 'UTF-8') . ',</p>' .
+                        '<p>Confirmamos la acreditación del pago por transferencia correspondiente a tu capacitación <strong>' .
+                        htmlspecialchars($cursoNombre, ENT_QUOTES, 'UTF-8') . '</strong>.</p>' .
+                        '<p><strong>Detalle del pago</strong></p>' .
+                        '<ul>' .
+                        '<li>Monto acreditado: <strong>' . htmlspecialchars($montoLabel, ENT_QUOTES, 'UTF-8') . '</strong></li>' .
+                        '<li>Fecha de aprobación: ' . htmlspecialchars($ahoraLabel, ENT_QUOTES, 'UTF-8') . '</li>' .
+                        '<li>Método: Transferencia bancaria</li>' .
+                        '</ul>' .
+                        '<p>En las próximas horas nos pondremos en contacto para coordinar los pasos siguientes.</p>' .
+                        '<p>¡Gracias por confiar en el Instituto de Formación de Operadores!</p>';
+
+                    $mail->Body = $body;
+                    $mail->AltBody = strip_tags(str_replace(['<br>', '<br/>', '<br />'], "\n", $body));
+                    $mail->send();
+                } catch (Throwable $mailError) {
+                    $emailError = $mailError->getMessage();
+                    log_cursos('transferencia_mail_error', ['id_pago' => $pagoId], $mailError);
+                }
+            }
+        }
+
+        $mensajeBase = $isAprobarPagoTransferencia
+            ? 'El pago fue aprobado correctamente.'
+            : 'El pago fue rechazado correctamente.';
+
+        if ($emailError !== null) {
+            $_SESSION['pagos_admin_success'] = $mensajeBase;
+            $_SESSION['pagos_admin_warning'] = 'No se pudo enviar el correo al alumno: ' . $emailError;
+        } else {
+            $_SESSION['pagos_admin_success'] = $mensajeBase;
+        }
+
+        log_cursos('pago_transferencia_actualizado', [
+            'id_pago' => $pagoId,
+            'accion' => $isAprobarPagoTransferencia ? 'aprobar' : 'rechazar',
+            'tipo' => $tipoCheckout,
+        ]);
+
+        header('Location: pagos.php');
         exit;
     }
 
@@ -1162,6 +1383,12 @@ try {
             $redirect .= '?' . http_build_query($params);
         }
         header('Location: ' . $redirect);
+        exit;
+    }
+
+    if ($isAprobarPagoTransferencia || $isRechazarPagoTransferencia) {
+        $_SESSION['pagos_admin_error'] = $e->getMessage();
+        header('Location: pagos.php');
         exit;
     }
 

--- a/checkout/gracias_certificacion.php
+++ b/checkout/gracias_certificacion.php
@@ -48,7 +48,7 @@ if (!$data && $certificacionId > 0) {
         $data = [
             'id_certificacion' => (int) $row['id_certificacion'],
             'id_curso' => (int) $row['id_curso'],
-            'curso_nombre' => (string) ($row['nombre_certificacion'] ?? $row['nombre_curso'] ?? ''),
+            'curso_nombre' => (string) ($row['nombre_curso'] ?? ''),
             'nombre' => (string) ($row['nombre'] ?? ''),
             'apellido' => (string) ($row['apellido'] ?? ''),
             'email' => (string) ($row['email'] ?? ''),

--- a/historial_compras.php
+++ b/historial_compras.php
@@ -214,6 +214,7 @@ $scriptName = basename((string)($_SERVER['PHP_SELF'] ?? 'historial_compras.php')
                                     <th class="text-start">Tipo</th>
                                     <th class="text-start">Curso</th>
                                     <th class="text-start">Estado</th>
+                                    <th class="text-center">Acciones</th>
                                     <th class="text-end">Total</th>
                                 </tr>
                                 </thead>
@@ -225,6 +226,22 @@ $scriptName = basename((string)($_SERVER['PHP_SELF'] ?? 'historial_compras.php')
                                         <td class="text-start"><?php echo $row['tipo'] === 'capacitacion' ? 'Capacitaci&oacute;n' : 'Certificaci&oacute;n'; ?></td>
                                         <td class="text-start"><?php echo htmlspecialchars($row['curso'] ?? 'Curso', ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td class="text-start"><?php echo htmlspecialchars($row['estado_label'] ?? '—', ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td class="text-center">
+                                            <?php if (($row['tipo'] ?? '') === 'certificacion'): ?>
+                                                <?php $estadoCert = isset($row['id_estado']) ? (int)$row['id_estado'] : 0; ?>
+                                                <?php if ($estadoCert === 2 && isset($row['id_curso']) && (int)$row['id_curso'] > 0): ?>
+                                                    <a class="btn btn-sm btn-gradient" href="checkout/checkout.php?tipo=certificacion&amp;id_curso=<?php echo (int)$row['id_curso']; ?>">
+                                                        Pagar
+                                                    </a>
+                                                <?php elseif ($estadoCert === 3): ?>
+                                                    <span class="badge bg-success">Pagado</span>
+                                                <?php else: ?>
+                                                    <span class="text-muted">—</span>
+                                                <?php endif; ?>
+                                            <?php else: ?>
+                                                <span class="text-muted">—</span>
+                                            <?php endif; ?>
+                                        </td>
                                         <td class="text-end"><?php echo htmlspecialchars($totalLabel, ENT_QUOTES, 'UTF-8'); ?></td>
                                     </tr>
                                 <?php endforeach; ?>
@@ -299,6 +316,7 @@ $scriptName = basename((string)($_SERVER['PHP_SELF'] ?? 'historial_compras.php')
                                         <th class="text-start">Curso</th>
                                         <th class="text-start">Estado</th>
                                         <th class="text-start">PDF</th>
+                                        <th class="text-start">Acciones</th>
                                         <th class="text-end">Total</th>
                                     </tr>
                                     </thead>
@@ -316,6 +334,18 @@ $scriptName = basename((string)($_SERVER['PHP_SELF'] ?? 'historial_compras.php')
                                                     </a>
                                                 <?php else: ?>
                                                     —
+                                                <?php endif; ?>
+                                            </td>
+                                            <td class="text-start">
+                                                <?php $estadoCert = isset($cert['id_estado']) ? (int)$cert['id_estado'] : 0; ?>
+                                                <?php if ($estadoCert === 2 && isset($cert['id_curso']) && (int)$cert['id_curso'] > 0): ?>
+                                                    <a class="btn btn-sm btn-gradient" href="checkout/checkout.php?tipo=certificacion&amp;id_curso=<?php echo (int)$cert['id_curso']; ?>">
+                                                        Pagar
+                                                    </a>
+                                                <?php elseif ($estadoCert === 3): ?>
+                                                    <span class="badge bg-success">Pagado</span>
+                                                <?php else: ?>
+                                                    <span class="text-muted">—</span>
                                                 <?php endif; ?>
                                             </td>
                                             <td class="text-end"><?php echo htmlspecialchars($totalLabel, ENT_QUOTES, 'UTF-8'); ?></td>
@@ -453,9 +483,9 @@ $scriptName = basename((string)($_SERVER['PHP_SELF'] ?? 'historial_compras.php')
 
     document.addEventListener('DOMContentLoaded', function() {
         // Índices de columna "Curso":
-        // recentTable: Fecha(0), Tipo(1), Curso(2), Estado(3), Total(4) => curso = 2
-        // capTable:    Fecha(0), Curso(1), Estado(2), Total(3)          => curso = 1
-        // certTable:   Fecha(0), Curso(1), Estado(2), PDF(3), Total(4)  => curso = 1
+        // recentTable: Fecha(0), Tipo(1), Curso(2), Estado(3), Acciones(4), Total(5) => curso = 2
+        // capTable:    Fecha(0), Curso(1), Estado(2), Total(3)                     => curso = 1
+        // certTable:   Fecha(0), Curso(1), Estado(2), PDF(3), Acciones(4), Total(5) => curso = 1
         setupPagerWithFilter({ tableId: 'recentTable', pagerId: 'recentPager', searchInputId: 'recentSearch', pageSize: 10, courseColIndex: 2 });
         setupPagerWithFilter({ tableId: 'capTable',    pagerId: 'capPager',    searchInputId: 'capSearch',    pageSize: 10, courseColIndex: 1 });
         setupPagerWithFilter({ tableId: 'certTable',   pagerId: 'certPager',   searchInputId: 'certSearch',   pageSize: 10, courseColIndex: 1 });


### PR DESCRIPTION
## Summary
- ensure admin payment listings only reference available course name fields
- keep certification requests in the approved state until a transfer is confirmed and retain applicant contact details when logging a payment
- clean up the certification confirmation page to rely on the course name column present in the schema

## Testing
- php -l admin/pagos.php
- php -l admin/procesarsbd.php
- php -l checkout/gracias_certificacion.php

------
https://chatgpt.com/codex/tasks/task_e_68e47c66a6908322a9c1e6064c6d8e7b